### PR TITLE
Set up development environment (dev docs + gitignore)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Python virtual environment (dev setup)
+.venv/
+
+# Generated MFA QR artifact
+mfa/mfa_qr.png
+
+# Python caches
+__pycache__/
+*.pyc

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repo (`ejoliet.github.io`) is a **static GitHub Pages site** plus one small self-hostable backend. There is **no build/lint/test tooling** anywhere (no `package.json`, `Makefile`, CI, or test framework); front-end libraries are CDN-loaded and there is no build step.
+
+### Services
+
+**1. Static site (all HTML demos + landing page).** The root `index.html` links to demos under `demo/`, `sofia/`, `radar/`, `nexsci-neid/`, `firefly-help/`, `mosaic/`, `ics/`, `family-p2p/`. Serve with any static server from the repo root:
+
+```bash
+python3 -m http.server 8080   # then open http://localhost:8080/
+```
+
+- Fully client-side tools that work offline: `ics/webcal.html` (generates a 1-hr `.ics` event) and the landing page.
+- Firefly demos (`sofia`, `radar`, `nexsci-neid`, `firefly-help`) fetch data from external Caltech/IRSA servers (`irsa*.ipac.caltech.edu`); `mosaic` pulls external HLS video streams. These degrade to empty viewers without internet and cannot be self-hosted.
+- `family-p2p/` (WebRTC video chat) needs a **secure/HTTPS context** for camera access — it will not get camera over plain `http://localhost`.
+
+**2. MFA OTP microservice (`mfa/`).** A Flask + pyotp service exposing `POST /validate_otp`. The only self-hosted backend.
+
+- `mfa/app.py` **hardcodes `host=0.0.0.0, port=8000`** (no port env var). If you run the static server on 8000 too, Flask fails with "Address already in use" — run them on **different ports** (e.g. static on 8080, MFA on 8000).
+- Requires the `OTP_SECRET` env var (the TOTP base32 secret). Generate one with `mfa/generate_mfa.py` (prints a `Secret Key` + writes `mfa_qr.png`). Get the current OTP for testing with `mfa/check_mfa.py <secret>`.
+- Run and test:
+
+```bash
+cd mfa
+OTP_SECRET=<secret> ../.venv/bin/python app.py            # serves on :8000
+OTP=$(../.venv/bin/python check_mfa.py <secret>)
+curl -s -X POST http://localhost:8000/validate_otp \
+  -H "Content-Type: application/json" -d "{\"otp\":\"$OTP\"}"   # -> {"status":"success"}
+```
+
+### Python environment
+
+Python deps live only in `mfa/requirements.txt` and are installed into a repo-local `.venv` (gitignored) by the startup update script. Use `.venv/bin/python` to run the MFA scripts/app. The `Dockerfile` pins Python 3.9, but the deps also run fine on the system Python 3.12 used here.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and documents the development environment for this repo (`ejoliet.github.io`), a static GitHub Pages site plus one self-hostable Flask/pyotp MFA microservice. No application code was changed.

- Add `AGENTS.md` with `## Cursor Cloud specific instructions` describing the two services and non-obvious gotchas (e.g. `mfa/app.py` hardcodes port 8000, so run the static server on a different port; MFA requires `OTP_SECRET`; `family-p2p` needs HTTPS; Firefly/mosaic demos rely on external servers).
- Add `.gitignore` for the dev virtualenv (`.venv/`), the generated `mfa/mfa_qr.png`, and Python caches.

The startup update script (configured via the environment tool) creates a repo-local `.venv` and installs `mfa/requirements.txt`.

## Verification

Static site server:
[Landing page](https://cursor.com/agents/bc-e5665424-e622-4d20-8959-9a8bfa0c0212/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flanding_page.webp)

ICS generator (client-side hello-world action — generated an event with SUMMARY "Cursor Cloud Setup Demo"):
[static_site_ics_generator_demo.mp4](https://cursor.com/agents/bc-e5665424-e622-4d20-8959-9a8bfa0c0212/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstatic_site_ics_generator_demo.mp4)

MFA OTP microservice end-to-end (`POST /validate_otp`): valid OTP → `success`, invalid → `failure`.
[mfa_validate_otp_test.log](https://cursor.com/agents/bc-e5665424-e622-4d20-8959-9a8bfa0c0212/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmfa_validate_otp_test.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e5665424-e622-4d20-8959-9a8bfa0c0212"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e5665424-e622-4d20-8959-9a8bfa0c0212"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

