### PR TITLE
Add War Room: P2P incident note rail with Markdown export

### DIFF
--- a/warroom/index.html
+++ b/warroom/index.html
@@ -1,0 +1,523 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>War Room — incident note rail</title>
+<!-- AIDEV-NOTE: single-file P2P incident note rail. PeerJS 1.5.5 + free PeerJS Cloud signaling.
+     Star topology: first opener hosts; host's browser is the server. Notes flow over
+     reliable DataConnections; host stamps ts+seq so every peer renders an identical log.
+     No backend, no accounts. Log mirrored to localStorage per room so reloads are safe. -->
+<script src="https://unpkg.com/peerjs@1.5.5/dist/peerjs.min.js"></script>
+<style>
+  :root{
+    --bg:#12141a;
+    --panel:#1a1d26;
+    --panel-2:#20242f;
+    --ink:#e8e6e1;
+    --soft:#8b90a0;
+    --line:#2c3140;
+    --go:#2ea24a;
+    --go-press:#1e7a3c;
+    --warn:#e0a63c;
+    --stop:#d64541;
+    --mono:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html,body{height:100%}
+  body{
+    font-family:-apple-system,system-ui,"Segoe UI",Roboto,Arial,sans-serif;
+    background:var(--bg);color:var(--ink);
+    display:flex;flex-direction:column;
+  }
+  button{font:inherit;cursor:pointer;border:none;border-radius:10px}
+  input{font:inherit}
+
+  /* ---------- join screen ---------- */
+  #join{
+    flex:1;display:flex;flex-direction:column;align-items:center;justify-content:center;
+    gap:20px;text-align:center;padding:24px;
+  }
+  #join h1{font-size:1.9rem;letter-spacing:-.01em}
+  #join p{color:var(--soft);max-width:30rem;line-height:1.5}
+  #nameInput{
+    background:var(--panel);color:var(--ink);border:1px solid var(--line);
+    border-radius:12px;padding:14px 18px;font-size:1.15rem;width:min(20rem,90vw);text-align:center;
+  }
+  #nameInput:focus{outline:2px solid var(--go)}
+  #joinBtn{
+    background:var(--go);color:#fff;font-size:1.25rem;font-weight:700;
+    padding:16px 36px;box-shadow:0 4px 0 var(--go-press);
+  }
+  #joinBtn:active{transform:translateY(3px);box-shadow:0 1px 0 var(--go-press)}
+  #joinBtn:disabled{opacity:.5;cursor:default}
+
+  /* ---------- room screen ---------- */
+  #room{flex:1;display:none;flex-direction:column;min-height:0}
+  #room.on{display:flex}
+
+  header{
+    display:flex;align-items:center;gap:12px;flex-wrap:wrap;
+    padding:12px 16px;background:var(--panel);border-bottom:1px solid var(--line);
+  }
+  header .title{font-weight:700;font-size:1.05rem;white-space:nowrap}
+  .dot{width:10px;height:10px;border-radius:50%;background:var(--warn);flex:none}
+  .dot.ok{background:var(--go)}
+  .dot.bad{background:var(--stop)}
+  #statusText{color:var(--soft);font-size:.9rem;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+  header .spacer{flex:1}
+  header button{
+    background:var(--panel-2);color:var(--ink);border:1px solid var(--line);
+    padding:8px 14px;font-size:.9rem;font-weight:600;
+  }
+  header button:hover{background:#272c39}
+
+  #banner{
+    display:none;padding:10px 16px;background:#3a2f18;color:#f0d9a8;
+    font-size:.92rem;border-bottom:1px solid #57431c;
+  }
+  #banner.on{display:block}
+
+  /* ---------- rail ---------- */
+  #rail{flex:1;overflow-y:auto;padding:14px 16px 8px;scroll-behavior:smooth}
+  #empty{color:var(--soft);text-align:center;padding:40px 20px;line-height:1.6}
+  #empty code{font-family:var(--mono);background:var(--panel);padding:2px 6px;border-radius:6px}
+  .entry{
+    display:flex;gap:10px;align-items:baseline;
+    padding:7px 8px;border-radius:8px;line-height:1.45;
+  }
+  .entry:hover{background:var(--panel)}
+  .entry .ts{
+    font-family:var(--mono);font-size:.82rem;color:var(--soft);
+    flex:none;padding-top:2px;
+  }
+  .entry .who{font-weight:700;font-size:.92rem;flex:none}
+  .entry .text{font-size:.98rem;word-break:break-word;white-space:pre-wrap}
+
+  /* ---------- composer ---------- */
+  #composer{
+    display:flex;gap:10px;padding:12px 16px calc(12px + env(safe-area-inset-bottom));
+    background:var(--panel);border-top:1px solid var(--line);
+  }
+  #noteInput{
+    flex:1;background:var(--bg);color:var(--ink);border:1px solid var(--line);
+    border-radius:12px;padding:12px 16px;font-size:1rem;min-width:0;
+  }
+  #noteInput:focus{outline:2px solid var(--go)}
+  #noteInput:disabled{opacity:.5}
+  #addBtn{
+    background:var(--go);color:#fff;font-weight:700;padding:12px 22px;font-size:1rem;
+    box-shadow:0 3px 0 var(--go-press);
+  }
+  #addBtn:active{transform:translateY(2px);box-shadow:0 1px 0 var(--go-press)}
+  #addBtn:disabled{opacity:.5;cursor:default;transform:none}
+</style>
+</head>
+<body>
+
+<!-- Screen 1: name + join/start -->
+<section id="join">
+  <h1 id="joinTitle">Incident war room</h1>
+  <p id="joinText">A shared, timestamped note rail for the incident bridge. No accounts, no server — notes flow directly between the browsers in the room.</p>
+  <input id="nameInput" placeholder="Your name or handle" maxlength="40" autocomplete="nickname">
+  <button id="joinBtn">Start a room</button>
+  <p id="joinHint" class="soft" style="color:var(--soft);font-size:.9rem"></p>
+</section>
+
+<!-- Screen 2: the rail -->
+<section id="room">
+  <header>
+    <span class="dot" id="statusDot"></span>
+    <span class="title">War Room</span>
+    <span id="statusText">connecting…</span>
+    <span class="spacer"></span>
+    <button id="tzBtn" title="Toggle timestamp timezone">UTC</button>
+    <button id="copyLinkBtn">Copy room link</button>
+    <button id="copyMdBtn">Copy Markdown</button>
+    <button id="dlBtn">Download .md</button>
+  </header>
+  <div id="banner"></div>
+  <div id="rail">
+    <div id="empty">
+      No notes yet. Drop the room link in the incident channel, then log what happens:<br>
+      <code>rolled back deploy</code> · <code>paged DB on-call</code> · <code>error rate recovering</code>
+    </div>
+  </div>
+  <div id="composer">
+    <input id="noteInput" placeholder="What just happened?" maxlength="2000" autocomplete="off">
+    <button id="addBtn">Add</button>
+  </div>
+</section>
+
+<script>
+"use strict";
+
+/* ================= config ================= */
+const MAX_RETRIES   = 8;
+const RETRY_DELAY_MS = 3000;
+const ROOM_PREFIX   = "warroom-";
+const ICE = null; // null = PeerJS defaults (Google STUN). Add TURN here if needed.
+
+/* ================= state ================= */
+const params  = new URLSearchParams(location.search);
+const urlRoom = params.get("room");
+// AIDEV-NOTE: host reload safety — the host remembers it owns a room id in
+// localStorage. On reload with ?room=X it re-claims X and restores the log,
+// so the link shared in Slack keeps working mid-incident.
+const isHost  = !urlRoom || localStorage.getItem(lsKey(urlRoom, "host")) === "1";
+
+let roomId   = urlRoom || null;
+let myName   = "";
+let peer     = null;
+let hostConn = null;            // guest: connection to host
+const conns  = new Map();       // host: peerId -> {conn, name}
+let entries  = [];              // {id, ts, seq, author, text}
+let seq      = 0;
+let retries  = 0, retryTimer = null, closed = false;
+let showUTC  = localStorage.getItem("warroom:tz") !== "local";
+
+/* ================= helpers ================= */
+const $ = id => document.getElementById(id);
+function lsKey(room, what){ return "warroom:" + room + ":" + what; }
+function randId(){ return Math.random().toString(36).slice(2, 10); }
+
+function fmtTime(ts){
+  const d = new Date(ts);
+  const p = n => String(n).padStart(2, "0");
+  return showUTC
+    ? p(d.getUTCHours()) + ":" + p(d.getUTCMinutes()) + ":" + p(d.getUTCSeconds())
+    : p(d.getHours()) + ":" + p(d.getMinutes()) + ":" + p(d.getSeconds());
+}
+function fmtDateUTC(ts){
+  const d = new Date(ts), p = n => String(n).padStart(2, "0");
+  return d.getUTCFullYear() + "-" + p(d.getUTCMonth()+1) + "-" + p(d.getUTCDate());
+}
+function authorColor(name){
+  let h = 0;
+  for (let i = 0; i < name.length; i++) h = (h * 31 + name.charCodeAt(i)) >>> 0;
+  return "hsl(" + (h % 360) + " 55% 70%)";
+}
+function setStatus(cls, text){
+  $("statusDot").className = "dot" + (cls ? " " + cls : "");
+  $("statusText").textContent = text;
+}
+function banner(msg){
+  const b = $("banner");
+  b.textContent = msg || "";
+  b.classList.toggle("on", !!msg);
+}
+
+/* ================= log store ================= */
+function persist(){
+  try{ localStorage.setItem(lsKey(roomId, "entries"), JSON.stringify(entries)); }catch(e){}
+}
+function restore(){
+  try{
+    const raw = localStorage.getItem(lsKey(roomId, "entries"));
+    if (raw) entries = JSON.parse(raw);
+    seq = entries.reduce((m, e) => Math.max(m, e.seq || 0), 0);
+  }catch(e){ entries = []; }
+}
+function upsert(entry){
+  if (entries.some(e => e.id === entry.id)) return false;
+  entries.push(entry);
+  entries.sort((a, b) => (a.ts - b.ts) || ((a.seq||0) - (b.seq||0)) || (a.id < b.id ? -1 : 1));
+  return true;
+}
+
+/* ================= rendering ================= */
+function renderAll(){
+  const rail = $("rail");
+  rail.querySelectorAll(".entry").forEach(n => n.remove());
+  $("empty").style.display = entries.length ? "none" : "";
+  for (const e of entries) rail.appendChild(entryNode(e));
+  rail.scrollTop = rail.scrollHeight;
+}
+function entryNode(e){
+  const row = document.createElement("div");
+  row.className = "entry";
+  const ts = document.createElement("span");
+  ts.className = "ts";
+  ts.textContent = fmtTime(e.ts);
+  ts.title = new Date(e.ts).toISOString();
+  const who = document.createElement("span");
+  who.className = "who";
+  who.textContent = e.author;
+  who.style.color = authorColor(e.author);
+  const text = document.createElement("span");
+  text.className = "text";
+  text.textContent = e.text;
+  row.append(ts, who, text);
+  return row;
+}
+function appendAndRender(entry){
+  if (!upsert(entry)) return;
+  persist();
+  // fast path: entry belongs at the end (the common case)
+  const last = entries[entries.length - 1];
+  const rail = $("rail");
+  if (last && last.id === entry.id){
+    $("empty").style.display = "none";
+    const nearBottom = rail.scrollHeight - rail.scrollTop - rail.clientHeight < 120;
+    rail.appendChild(entryNode(entry));
+    if (nearBottom) rail.scrollTop = rail.scrollHeight;
+  } else {
+    renderAll();
+  }
+}
+
+/* ================= boot ================= */
+myName = localStorage.getItem("warroom:name") || "";
+$("nameInput").value = myName;
+$("tzBtn").textContent = showUTC ? "UTC" : "local";
+
+if (urlRoom && !isHost){
+  $("joinTitle").textContent = "Join the war room";
+  $("joinText").textContent  = "You've been invited to an incident note rail. Enter your name so teammates know who logged what.";
+  $("joinBtn").textContent   = "Join room";
+} else if (urlRoom && isHost){
+  $("joinHint").textContent  = "Rejoining the room you started — your notes are saved on this device.";
+}
+
+$("joinBtn").addEventListener("click", begin);
+$("nameInput").addEventListener("keydown", e => { if (e.key === "Enter") begin(); });
+$("addBtn").addEventListener("click", addNote);
+$("noteInput").addEventListener("keydown", e => { if (e.key === "Enter") addNote(); });
+$("tzBtn").addEventListener("click", () => {
+  showUTC = !showUTC;
+  localStorage.setItem("warroom:tz", showUTC ? "utc" : "local");
+  $("tzBtn").textContent = showUTC ? "UTC" : "local";
+  renderAll();
+});
+$("copyLinkBtn").addEventListener("click", async () => {
+  const link = location.origin + location.pathname + "?room=" + roomId;
+  try{ await navigator.clipboard.writeText(link); flash("copyLinkBtn", "Copied ✓"); }
+  catch(e){ prompt("Copy this link:", link); }
+});
+$("copyMdBtn").addEventListener("click", async () => {
+  try{ await navigator.clipboard.writeText(toMarkdown()); flash("copyMdBtn", "Copied ✓"); }
+  catch(e){}
+});
+$("dlBtn").addEventListener("click", downloadMd);
+
+function flash(id, text){
+  const b = $(id), old = b.textContent;
+  b.textContent = text;
+  setTimeout(() => b.textContent = old, 2000);
+}
+
+function begin(){
+  const name = $("nameInput").value.trim();
+  if (!name){ $("nameInput").focus(); return; }
+  myName = name;
+  localStorage.setItem("warroom:name", name);
+  $("joinBtn").disabled = true;
+  isHost ? startHost() : startGuest();
+}
+
+/* ================= host side ================= */
+function startHost(){
+  roomId = urlRoom || ROOM_PREFIX + randId();
+  restore();
+  peer = makePeer(roomId);
+
+  peer.on("open", () => {
+    localStorage.setItem(lsKey(roomId, "host"), "1");
+    persist();
+    // make the address bar itself the shareable link
+    history.replaceState(null, "", location.pathname + "?room=" + roomId);
+    enterRoom();
+    setStatus("ok", "you're hosting · 1 in room");
+    if (!entries.length)
+      banner("You're live. Copy the room link into the incident channel so others can join.");
+  });
+
+  peer.on("connection", conn => {
+    conn.on("open", () => {
+      conns.set(conn.peer, { conn, name: "?" });
+      conn.send({ type: "snapshot", entries });
+      broadcastPresence();
+    });
+    conn.on("data", msg => {
+      if (!msg || typeof msg !== "object") return;
+      if (msg.type === "hello"){
+        const c = conns.get(conn.peer);
+        if (c) c.name = String(msg.author || "?").slice(0, 40);
+        broadcastPresence();
+      } else if (msg.type === "add"){
+        acceptEntry(String(msg.text || ""), String(msg.author || "?"), String(msg.id || randId()));
+      }
+    });
+    const drop = () => { conns.delete(conn.peer); broadcastPresence(); };
+    conn.on("close", drop);
+    conn.on("error", drop);
+  });
+}
+
+// AIDEV-NOTE: host stamps ts+seq so all peers share one canonical order,
+// immune to guests' skewed clocks.
+function acceptEntry(text, author, id){
+  text = text.trim();
+  if (!text) return;
+  const entry = { id, ts: Date.now(), seq: ++seq, author: author.slice(0, 40), text: text.slice(0, 2000) };
+  appendAndRender(entry);
+  broadcast({ type: "entry", entry });
+  banner("");
+}
+function broadcast(msg){
+  for (const { conn } of conns.values()){
+    try{ conn.send(msg); }catch(e){}
+  }
+}
+function broadcastPresence(){
+  const count = conns.size + 1;
+  setStatus("ok", "you're hosting · " + count + " in room");
+  broadcast({ type: "presence", count });
+}
+
+/* ================= guest side ================= */
+function startGuest(){
+  restore(); // show any locally saved copy immediately
+  peer = makePeer(); // random id from signaling server
+  peer.on("open", connectToHost);
+}
+
+function connectToHost(){
+  if (closed) return;
+  enterRoom();
+  if (entries.length) renderAll();
+  setStatus("", retries === 0 ? "connecting…" : "reconnecting (" + retries + "/" + MAX_RETRIES + ")…");
+  $("noteInput").disabled = $("addBtn").disabled = true;
+
+  if (hostConn) try{ hostConn.close(); }catch(e){}
+  const conn = hostConn = peer.connect(roomId, { reliable: true });
+  if (!conn){ scheduleRetry(); return; }
+
+  conn.on("open", () => {
+    if (conn !== hostConn) return;
+    retries = 0;
+    conn.send({ type: "hello", author: myName });
+    $("noteInput").disabled = $("addBtn").disabled = false;
+    setStatus("ok", "connected");
+    banner("");
+  });
+  conn.on("data", msg => {
+    if (!msg || typeof msg !== "object") return;
+    if (msg.type === "snapshot"){
+      for (const e of msg.entries || []) upsert(e);
+      persist();
+      renderAll();
+    } else if (msg.type === "entry"){
+      appendAndRender(msg.entry);
+    } else if (msg.type === "presence"){
+      setStatus("ok", "connected · " + msg.count + " in room");
+    }
+  });
+  const drop = () => {
+    if (closed || conn !== hostConn) return; // stale connection from an earlier attempt
+    scheduleRetry();
+  };
+  conn.on("close", drop);
+  conn.on("error", drop);
+}
+
+function scheduleRetry(){
+  if (closed) return;
+  clearTimeout(retryTimer);
+  retries++;
+  $("noteInput").disabled = $("addBtn").disabled = true;
+  if (retries > MAX_RETRIES){
+    setStatus("bad", "disconnected");
+    banner("Can't reach the room host. Your copy of the log is safe on this device — you can still export it, or reload to retry.");
+    return;
+  }
+  setStatus("", "reconnecting (" + retries + "/" + MAX_RETRIES + ")…");
+  banner("Lost the host — reconnecting. Your copy of the log is safe on this device.");
+  retryTimer = setTimeout(connectToHost, RETRY_DELAY_MS);
+}
+
+/* ================= shared ================= */
+function makePeer(id){
+  const opts = { debug: 1 };
+  if (ICE) opts.config = ICE;
+  const p = id ? new Peer(id, opts) : new Peer(opts);
+
+  p.on("disconnected", () => { if (!closed && !p.destroyed) p.reconnect(); });
+
+  p.on("error", err => {
+    if (closed) return;
+    if (err.type === "unavailable-id"){
+      banner("This room is already open in another tab or window. Close it there, or use that tab instead.");
+      setStatus("bad", "room open elsewhere");
+      return;
+    }
+    if (err.type === "peer-unavailable"){
+      if (!isHost) scheduleRetry(); // host not up yet or refreshed — keep trying
+      return;
+    }
+    if (!isHost) scheduleRetry();
+    else setStatus("bad", "signaling problem — reload to retry");
+  });
+  return p;
+}
+
+function enterRoom(){
+  $("join").style.display = "none";
+  $("room").classList.add("on");
+  renderAll();
+  $("noteInput").focus();
+}
+
+function addNote(){
+  const text = $("noteInput").value.trim();
+  if (!text) return;
+  if (isHost){
+    acceptEntry(text, myName, randId());
+  } else {
+    if (!hostConn || !hostConn.open) return;
+    hostConn.send({ type: "add", id: randId(), author: myName, text });
+  }
+  $("noteInput").value = "";
+  $("noteInput").focus();
+}
+
+/* ================= export ================= */
+function toMarkdown(){
+  const now = Date.now();
+  const lines = [];
+  lines.push("# Incident log — " + fmtDateUTC(entries[0]?.ts ?? now));
+  lines.push("");
+  lines.push("_Exported " + new Date(now).toISOString().replace("T", " ").slice(0, 16) +
+             " UTC · " + entries.length + " note" + (entries.length === 1 ? "" : "s") + "_");
+  lines.push("");
+  let lastDay = "";
+  for (const e of entries){
+    const day = fmtDateUTC(e.ts);
+    if (day !== lastDay && lastDay !== ""){
+      lines.push("");
+      lines.push("### " + day);
+      lines.push("");
+    }
+    lastDay = day;
+    const d = new Date(e.ts), p = n => String(n).padStart(2, "0");
+    const t = p(d.getUTCHours()) + ":" + p(d.getUTCMinutes()) + ":" + p(d.getUTCSeconds());
+    lines.push("- **" + t + " UTC** — **" + e.author + "**: " + e.text.replace(/\n/g, " "));
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+function downloadMd(){
+  const blob = new Blob([toMarkdown()], { type: "text/markdown" });
+  const a = document.createElement("a");
+  const d = new Date(), p = n => String(n).padStart(2, "0");
+  a.href = URL.createObjectURL(blob);
+  a.download = "incident-log-" + d.getUTCFullYear() + p(d.getUTCMonth()+1) + p(d.getUTCDate()) +
+               "-" + p(d.getUTCHours()) + p(d.getUTCMinutes()) + ".md";
+  a.click();
+  URL.revokeObjectURL(a.href);
+}
+
+window.addEventListener("beforeunload", () => { if (peer) try{ peer.destroy(); }catch(e){} });
+</script>
+</body>
+</html>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `warroom/index.html` — a single-file, zero-backend incident note rail in the same style as `family-p2p`:

- **Shared timestamped append-only log.** Everyone in the room sees the same rail; entries are stamped by the host (timestamp + sequence number) so all peers render an identical canonical order regardless of guests' clock skew.
- **Link-as-onboarding.** First person to open the page becomes the host and gets a `?room=…` link to drop in the incident Slack channel. Joiners enter a name and are in.
- **Markdown export** for the postmortem: copy to clipboard or download as `.md`, with UTC timestamps and author attribution.
- **Resilience for incident conditions:** the log is mirrored to `localStorage` per room on every peer, so a reload (host or guest) restores it; the host re-claims its room ID after refresh so the shared link keeps working; guests auto-reconnect with retries and a clear "your copy is safe on this device" banner if the host vanishes.
- **UTC/local toggle** for displayed timestamps (export is always UTC).

## Architecture

Same pattern as `family-p2p/index.html`: PeerJS 1.5.5 + free PeerJS Cloud signaling, star topology with the host's browser acting as the server. Notes flow over reliable data channels; new joiners receive a full snapshot, then incremental entries. No accounts, no server-side state.

## Testing

Verified with two headless Chromium instances (host + guest) exchanging notes through the real PeerJS Cloud signaling service, including snapshot delivery to a late joiner and Markdown export output.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-97d3fd1a-9c4d-42f6-8cea-3f93c8b37ec0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-97d3fd1a-9c4d-42f6-8cea-3f93c8b37ec0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

