### PR TITLE
family-multi-chat: file sharing, screen share, flip camera, big-file links

### DIFF
--- a/family-multi-chat/README.md
+++ b/family-multi-chat/README.md
@@ -2,6 +2,12 @@
 
 One HTML file. Browser-to-browser group video call over WebRTC. No install, no account, no server code of your own.
 
+## In-call features
+
+- **Send photo/file** — pictures and documents go directly peer-to-peer over the same encrypted data channels (never through a server). Images show as tappable thumbnails, documents as download links, in a tray above the buttons. Files up to 25 MB; the sender uploads one copy per participant (mesh).
+- **Share screen** — desktop browsers only (Chrome, Edge, Firefox, Safari on macOS); phones/tablets can watch but not share (platform limitation, the button is hidden there). Sent sharp but at low frame rate so text stays readable without extra bandwidth.
+- **Flip camera** — switch between front and back camera mid-call (shown only when the device has more than one camera). Uses `replaceTrack`, so the call is never interrupted.
+
 ## How it works
 
 - First person opens the page → **Start** → gets a room link → sends it.
@@ -34,7 +40,8 @@ Must be served over **HTTPS** (browser camera requirement):
 - **No TURN server**: works on most home networks (STUN only). Strict/symmetric NATs (some mobile carriers, corporate networks) may fail. Fix: fill in the `ICE` constant at the top of the script (see `AIDEV-NOTE`).
 - **Free PeerJS Cloud**: fine for personal use, not high traffic.
 - **4 people max** by design. Beyond that you need a media server — use Jitsi instead.
-- No recording, no chat, no accounts — on purpose.
+- No recording, no text chat, no accounts — on purpose.
+- Shared files are not stored anywhere: only people in the call when a file is sent receive it, and it lives only in their browser tab.
 
 ## Config knobs (top of the script)
 
@@ -43,5 +50,7 @@ Must be served over **HTTPS** (browser camera requirement):
 | `MAX_JOIN_RETRIES` | 8 | Room rejoin attempts before giving up |
 | `MAX_CALL_RETRIES` | 5 | Per-peer media reconnect attempts |
 | `RETRY_DELAY_MS` | 3000 | Delay between attempts |
-| `MEDIA` | 640×480 @ 24 | Outgoing stream cap (mesh bandwidth) |
+| `MEDIA` | 640×480 @ 24 | Outgoing camera stream cap (mesh bandwidth) |
+| `SCREEN_MEDIA` | ≤1920 wide @ 5 fps | Screen-share cap: sharp but slow, similar bandwidth to camera |
+| `MAX_FILE_MB` | 25 | Per-file size cap for photo/document sharing |
 | `ICE` | `null` (PeerJS default STUN) | Add TURN here if needed |

--- a/family-multi-chat/README.md
+++ b/family-multi-chat/README.md
@@ -5,6 +5,7 @@ One HTML file. Browser-to-browser group video call over WebRTC. No install, no a
 ## In-call features
 
 - **Send photo/file** — pictures and documents go directly peer-to-peer over the same encrypted data channels (never through a server). Images show as tappable thumbnails, documents as download links, in a tray above the buttons. Files up to 25 MB; the sender uploads one copy per participant (mesh).
+- **Big files (over 25 MB)** — the app guides you to [Wormhole](https://wormhole.app) (end-to-end encrypted, no account, up to 10 GB): upload there once, paste the link back, and it lands in everyone's tray — including people who join the call later. Downloads work even after the call ends; the link expires after 24 h. Only the link travels through the call's data channels, and the decryption key stays in the URL fragment.
 - **Share screen** — desktop browsers only (Chrome, Edge, Firefox, Safari on macOS); phones/tablets can watch but not share (platform limitation, the button is hidden there). Sent sharp but at low frame rate so text stays readable without extra bandwidth.
 - **Flip camera** — switch between front and back camera mid-call (shown only when the device has more than one camera). Uses `replaceTrack`, so the call is never interrupted.
 
@@ -41,7 +42,7 @@ Must be served over **HTTPS** (browser camera requirement):
 - **Free PeerJS Cloud**: fine for personal use, not high traffic.
 - **4 people max** by design. Beyond that you need a media server — use Jitsi instead.
 - No recording, no text chat, no accounts — on purpose.
-- Shared files are not stored anywhere: only people in the call when a file is sent receive it, and it lives only in their browser tab.
+- Directly shared files are not stored anywhere: only people in the call when a file is sent receive it, and it lives only in their browser tab. Big files handed off to Wormhole are stored there encrypted until the link expires (24 h).
 
 ## Config knobs (top of the script)
 
@@ -52,5 +53,6 @@ Must be served over **HTTPS** (browser camera requirement):
 | `RETRY_DELAY_MS` | 3000 | Delay between attempts |
 | `MEDIA` | 640×480 @ 24 | Outgoing camera stream cap (mesh bandwidth) |
 | `SCREEN_MEDIA` | ≤1920 wide @ 5 fps | Screen-share cap: sharp but slow, similar bandwidth to camera |
-| `MAX_FILE_MB` | 25 | Per-file size cap for photo/document sharing |
+| `MAX_FILE_MB` | 25 | Per-file size cap for direct photo/document sharing |
+| `BIG_FILE_URL` | `https://wormhole.app` | E2EE expiring-link service offered for bigger files |
 | `ICE` | `null` (PeerJS default STUN) | Add TURN here if needed |

--- a/family-multi-chat/index.html
+++ b/family-multi-chat/index.html
@@ -53,7 +53,8 @@
   #grid{
     flex:1;width:100%;display:grid;gap:6px;padding:6px;
     grid-template-columns:repeat(auto-fit,minmax(min(46vw,340px),1fr));
-    align-content:center;
+    align-content:center;align-content:safe center;
+    min-height:0;overflow-y:auto;  /* oversized tiles scroll instead of pushing the buttons off-screen */
   }
   .tile{position:relative;border-radius:14px;overflow:hidden;background:#1b1b1b;aspect-ratio:4/3}
   .tile video{width:100%;height:100%;object-fit:cover}
@@ -69,10 +70,27 @@
   #topbar .soft{color:#cfcabf}
   #statusLine{color:#ffd88a;font-size:1.1rem;font-weight:600;min-height:0}
   #bottombar{
-    width:100%;display:flex;justify-content:center;
+    width:100%;display:flex;justify-content:center;align-items:center;
+    gap:10px;flex-wrap:wrap;
     padding:12px 12px max(20px,env(safe-area-inset-bottom));
     background:rgba(0,0,0,.55);
   }
+
+  /* ---- shared files tray ---- */
+  #filesTray{
+    width:100%;display:flex;gap:12px;align-items:flex-start;overflow-x:auto;
+    padding:8px 12px;background:rgba(0,0,0,.55);
+  }
+  .fitem{
+    flex:none;display:flex;flex-direction:column;align-items:center;gap:4px;
+    color:#fff;font-size:.85rem;max-width:9rem;text-decoration:none;
+  }
+  .fitem img{width:72px;height:72px;object-fit:cover;border-radius:10px;background:#222}
+  .fitem .fdoc{
+    width:72px;height:72px;display:flex;align-items:center;justify-content:center;
+    font-size:2rem;background:#222;border-radius:10px;
+  }
+  .fitem span{max-width:9rem;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 </style>
 </head>
 <body>
@@ -103,7 +121,12 @@
     <span id="statusLine"></span>
   </div>
   <div id="grid"></div>
+  <div id="filesTray" hidden></div>
   <div id="bottombar">
+    <button id="flipBtn" class="secondary" hidden>Flip camera</button>
+    <button id="screenBtn" class="secondary" hidden>Share screen</button>
+    <button id="fileBtn" class="secondary">Send photo/file</button>
+    <input type="file" id="fileInput" hidden>
     <button id="hangupBtn" class="stop">Leave call</button>
   </div>
 </section>
@@ -126,6 +149,10 @@ const ROOM_PREFIX      = "famroom-";
 // AIDEV-NOTE: mesh bandwidth control — each person uploads (n-1) copies of this stream.
 // 640x480@24 keeps a 4-person call viable on ordinary home upload speeds.
 const MEDIA = { video: { width:{ideal:640}, height:{ideal:480}, frameRate:{ideal:24} }, audio: true };
+// AIDEV-NOTE: screen share is sent sharp but slow (high res, low fps) so text stays
+// readable while the mesh upload cost stays close to a camera stream.
+const SCREEN_MEDIA = { video: { frameRate:{ideal:5, max:5}, width:{max:1920} }, audio: false };
+const MAX_FILE_MB  = 25;        // per-file cap; sender uploads one copy per participant
 // AIDEV-NOTE: default PeerJS ICE = Google STUN only. If calls fail on strict/symmetric
 // NATs, add a TURN server (e.g. metered.ca free tier — verify current creds):
 // const ICE = { iceServers:[{urls:"stun:stun.l.google.com:19302"},
@@ -139,6 +166,10 @@ const roomURL = location.origin + location.pathname + "?room=" + roomId;
 
 let myName = "";
 let localStream = null;
+let cameraTrack = null;       // live camera video track (kept while screen sharing)
+let screenTrack = null;       // non-null while sharing the screen
+let facing = "user";          // current camera facing on phones
+let dataConns = {};           // mediaId -> DataConnection (file transfers)
 let mediaPeer = null;         // my identity in the mesh (random ID)
 let brokerPeer = null;        // held ONLY while I am the anchor (ID = roomId)
 let brokerConn = null;        // member -> anchor data connection (null while anchor)
@@ -172,6 +203,10 @@ if (params.get("room")){
 }
 $("startBtn").addEventListener("click", begin);
 $("hangupBtn").addEventListener("click", hangUp);
+$("flipBtn").addEventListener("click", flipCamera);
+$("screenBtn").addEventListener("click", toggleScreen);
+$("fileBtn").addEventListener("click", () => $("fileInput").click());
+$("fileInput").addEventListener("change", onFilePicked);
 $("againBtn").addEventListener("click", () => location.href = location.pathname);
 $("retryBtn").addEventListener("click", () => { joinRetries = 0; $("retryBtn").hidden = true; startMesh(); });
 
@@ -186,10 +221,22 @@ async function begin(){
     $("startBtn").disabled = false;
     return;
   }
+  cameraTrack = localStream.getVideoTracks()[0];
   addTile("me", localStream, "You", true);
   setupShareButtons();
+  setupControls();
   showScreen("connecting");
   startMesh();
+}
+
+// Show the flip button only when there is more than one camera, and the
+// screen-share button only where the browser supports it (desktop).
+async function setupControls(){
+  if (navigator.mediaDevices.getDisplayMedia) $("screenBtn").hidden = false;
+  try{
+    const devs = await navigator.mediaDevices.enumerateDevices();
+    if (devs.filter(d => d.kind === "videoinput").length > 1) $("flipBtn").hidden = false;
+  }catch(e){}
 }
 
 function setupShareButtons(){
@@ -215,6 +262,7 @@ function startMesh(){
 
   mediaPeer = new Peer(peerOpts());
   mediaPeer.on("open", claimOrJoin);
+  mediaPeer.on("connection", wireData);   // peer-to-peer file transfers
   mediaPeer.on("call", incoming => {
     // AIDEV-NOTE: always answer; dedupe by closing any stale call from the same peer
     const from = incoming.peer;
@@ -409,6 +457,144 @@ function wireCall(c){
   };
 }
 
+/* ================= camera & screen controls ================= */
+// AIDEV-NOTE: track swap — RTCRtpSender.replaceTrack() changes what everyone
+// receives without renegotiation, so flip camera / screen share never
+// interrupt the call. localStream is also updated so that new joiners and
+// re-connects (which are answered with localStream) get the current track.
+async function swapOutgoingVideo(newTrack){
+  const old = localStream.getVideoTracks()[0];
+  if (old === newTrack) return;
+  if (old) localStream.removeTrack(old);
+  localStream.addTrack(newTrack);
+  for (const c of Object.values(calls)){
+    const pc = c.peerConnection;
+    if (!pc) continue;
+    const sender = pc.getSenders().find(s => s.track && s.track.kind === "video");
+    if (sender) try{ await sender.replaceTrack(newTrack); }catch(e){}
+  }
+  const v = document.querySelector('.tile[data-peer="me"] video');
+  if (v) v.srcObject = localStream;
+}
+
+function getCam(mode){
+  return navigator.mediaDevices.getUserMedia(
+    { video: Object.assign({}, MEDIA.video, { facingMode: { ideal: mode } }), audio: false });
+}
+
+async function flipCamera(){
+  if (screenTrack) return;
+  $("flipBtn").disabled = true;
+  const want = facing === "user" ? "environment" : "user";
+  // AIDEV-NOTE: stop the current camera BEFORE opening the other one —
+  // iPhones refuse to run two cameras at once.
+  if (cameraTrack) try{ cameraTrack.stop(); }catch(e){}
+  let s = null;
+  try{ s = await getCam(want); facing = want; }
+  catch(e){ try{ s = await getCam(facing); }catch(e2){} }   // recover the old camera
+  if (s){
+    cameraTrack = s.getVideoTracks()[0];
+    await swapOutgoingVideo(cameraTrack);
+  } else {
+    status("Could not switch camera.");
+  }
+  $("flipBtn").disabled = false;
+}
+
+async function toggleScreen(){
+  if (screenTrack){ stopScreenShare(); return; }
+  let s;
+  try{ s = await navigator.mediaDevices.getDisplayMedia(SCREEN_MEDIA); }
+  catch(e){ return; }                       // user cancelled the picker
+  screenTrack = s.getVideoTracks()[0];
+  screenTrack.addEventListener("ended", stopScreenShare);  // browser's own Stop button
+  await swapOutgoingVideo(screenTrack);
+  $("screenBtn").textContent = "Stop sharing";
+  $("flipBtn").disabled = true;             // camera track stays live for instant return
+  status("You are sharing your screen", true);
+}
+
+function stopScreenShare(){
+  if (!screenTrack) return;
+  try{ screenTrack.stop(); }catch(e){}
+  screenTrack = null;
+  swapOutgoingVideo(cameraTrack);
+  $("screenBtn").textContent = "Share screen";
+  $("flipBtn").disabled = false;
+  status("");
+}
+
+/* ================= file sharing ================= */
+// AIDEV-NOTE: files go directly peer-to-peer over PeerJS data connections
+// (binary serialization auto-chunks big payloads) — no server ever sees them.
+// Mesh cost: the sender uploads one copy per other participant.
+function wireData(conn){
+  dataConns[conn.peer] = conn;
+  conn.on("data", msg => onFileMsg(conn.peer, msg));
+  const gone = () => { if (dataConns[conn.peer] === conn) delete dataConns[conn.peer]; };
+  conn.on("close", gone);
+  conn.on("error", gone);
+}
+
+function getDataConn(id, cb){
+  const c = dataConns[id];
+  if (c && c.open){ cb(c); return; }
+  const nc = mediaPeer.connect(id, { reliable: true });
+  wireData(nc);
+  nc.on("open", () => cb(nc));
+}
+
+async function onFilePicked(){
+  const f = $("fileInput").files[0];
+  $("fileInput").value = "";
+  if (!f) return;
+  if (f.size > MAX_FILE_MB * 1024 * 1024){
+    status("Too big — files up to " + MAX_FILE_MB + " MB only.");
+    return;
+  }
+  const others = Object.keys(knownMembers).filter(id => id !== mediaPeer.id);
+  if (!others.length){ status("No one else is in the call yet."); return; }
+  status("Sending " + f.name + "…");
+  const buf = await f.arrayBuffer();
+  for (const id of others){
+    getDataConn(id, conn => {
+      try{ conn.send({ t:"file", name: f.name, mime: f.type, data: buf }); }catch(e){}
+    });
+  }
+  addFileItem(f.name, f.type, new Blob([buf], { type: f.type }), "You");
+}
+
+function onFileMsg(fromId, msg){
+  if (!msg || msg.t !== "file" || !msg.data) return;
+  const blob = new Blob([msg.data], { type: msg.mime || "application/octet-stream" });
+  const who = knownMembers[fromId] || "Someone";
+  addFileItem(msg.name || "file", msg.mime || "", blob, who);
+  status(who + " shared " + (msg.name || "a file"));
+}
+
+function addFileItem(name, mime, blob, from){
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.className = "fitem";
+  a.href = url;
+  if ((mime || "").startsWith("image/")){
+    a.target = "_blank";                    // open to view; long-press/right-click to save
+    const img = document.createElement("img");
+    img.src = url; img.alt = name;
+    a.appendChild(img);
+  } else {
+    a.download = name;
+    const d = document.createElement("div");
+    d.className = "fdoc"; d.textContent = "📄";
+    a.appendChild(d);
+  }
+  const s = document.createElement("span");
+  s.textContent = (from ? from + ": " : "") + name;
+  a.appendChild(s);
+  $("filesTray").appendChild(a);
+  $("filesTray").hidden = false;
+}
+
 /* ================= tiles ================= */
 function addTile(id, stream, label, isLocal){
   removeTile(id);
@@ -417,6 +603,11 @@ function addTile(id, stream, label, isLocal){
   const v = document.createElement("video");
   v.autoplay = true; v.playsInline = true; if (isLocal) v.muted = true;
   v.srcObject = stream;
+  // Wide frames (screen shares) are letterboxed so text stays readable;
+  // camera frames fill the tile. Fires again when a track is swapped mid-call.
+  v.addEventListener("resize", () => {
+    v.style.objectFit = v.videoWidth / Math.max(1, v.videoHeight) > 1.55 ? "contain" : "cover";
+  });
   const tag = document.createElement("span");
   tag.className = "tag"; tag.textContent = label || "";
   tile.append(v, tag);
@@ -439,6 +630,9 @@ function hangUp(){
   clearTimeout(joinTimer);
   Object.values(callTimers).forEach(clearTimeout);
   Object.values(calls).forEach(c => { try{ c.close(); }catch(e){} });
+  Object.values(dataConns).forEach(c => { try{ c.close(); }catch(e){} });
+  if (screenTrack) try{ screenTrack.stop(); }catch(e){}
+  if (cameraTrack) try{ cameraTrack.stop(); }catch(e){}   // may be outside localStream while sharing
   if (brokerConn) try{ brokerConn.close(); }catch(e){}
   if (brokerPeer) try{ brokerPeer.destroy(); }catch(e){}   // frees roomId -> members elect new anchor
   if (mediaPeer)  try{ mediaPeer.destroy(); }catch(e){}

--- a/family-multi-chat/index.html
+++ b/family-multi-chat/index.html
@@ -91,6 +91,21 @@
     font-size:2rem;background:#222;border-radius:10px;
   }
   .fitem span{max-width:9rem;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+
+  /* ---- big-file (share via link) overlay ---- */
+  #bigfile{
+    position:absolute;inset:0;z-index:5;display:flex;align-items:center;justify-content:center;
+    background:rgba(0,0,0,.7);padding:20px;
+  }
+  #bigfile[hidden]{display:none}
+  #bigfile .card{
+    background:var(--paper);color:var(--ink);border-radius:20px;padding:24px;
+    max-width:28rem;width:100%;display:flex;flex-direction:column;gap:14px;text-align:center;
+    max-height:100%;overflow-y:auto;
+  }
+  #bigfile p{font-size:1.05rem;line-height:1.45}
+  #bigfile ol{text-align:left;font-size:1.05rem;line-height:1.5;padding-left:1.6rem}
+  #bigfile .err{color:var(--stop);font-size:1rem;min-height:1.2rem;margin:0}
 </style>
 </head>
 <body>
@@ -122,6 +137,25 @@
   </div>
   <div id="grid"></div>
   <div id="filesTray" hidden></div>
+  <div id="bigfile" hidden>
+    <div class="card">
+      <p id="bigfileText"></p>
+      <p>Share it as a private link instead — it keeps working even after the call:</p>
+      <ol>
+        <li>Press <b>Open Wormhole</b> and put the file there. It is end-to-end encrypted.</li>
+        <li>Copy the link Wormhole gives you.</li>
+        <li>Paste it below and press <b>Share link</b>.</li>
+      </ol>
+      <button id="wormholeBtn">Open Wormhole</button>
+      <input type="text" id="linkInput" placeholder="Paste the link here" autocomplete="off">
+      <p class="err" id="linkErr"></p>
+      <div class="row">
+        <button id="shareLinkBtn" class="secondary">Share link</button>
+        <button id="bigfileCancel" class="secondary">Cancel</button>
+      </div>
+      <p class="soft">The link stops working after 24 hours.</p>
+    </div>
+  </div>
   <div id="bottombar">
     <button id="flipBtn" class="secondary" hidden>Flip camera</button>
     <button id="screenBtn" class="secondary" hidden>Share screen</button>
@@ -153,6 +187,10 @@ const MEDIA = { video: { width:{ideal:640}, height:{ideal:480}, frameRate:{ideal
 // readable while the mesh upload cost stays close to a camera stream.
 const SCREEN_MEDIA = { video: { frameRate:{ideal:5, max:5}, width:{max:1920} }, audio: false };
 const MAX_FILE_MB  = 25;        // per-file cap; sender uploads one copy per participant
+// AIDEV-NOTE: bigger files hand off to an E2EE expiring-link service (no account
+// needed, one upload serves everyone, works after the call). Only the link travels
+// through our data channels; the decryption key stays in the URL fragment.
+const BIG_FILE_URL = "https://wormhole.app";
 // AIDEV-NOTE: default PeerJS ICE = Google STUN only. If calls fail on strict/symmetric
 // NATs, add a TURN server (e.g. metered.ca free tier — verify current creds):
 // const ICE = { iceServers:[{urls:"stun:stun.l.google.com:19302"},
@@ -170,6 +208,9 @@ let cameraTrack = null;       // live camera video track (kept while screen shar
 let screenTrack = null;       // non-null while sharing the screen
 let facing = "user";          // current camera facing on phones
 let dataConns = {};           // mediaId -> DataConnection (file transfers)
+let myLinks = [];             // links I shared: {url, name} — re-sent to late joiners
+let seenLinks = new Set();    // received link URLs (dedupes re-broadcasts)
+let bigFileName = "";         // file that triggered the big-file overlay
 let mediaPeer = null;         // my identity in the mesh (random ID)
 let brokerPeer = null;        // held ONLY while I am the anchor (ID = roomId)
 let brokerConn = null;        // member -> anchor data connection (null while anchor)
@@ -207,6 +248,9 @@ $("flipBtn").addEventListener("click", flipCamera);
 $("screenBtn").addEventListener("click", toggleScreen);
 $("fileBtn").addEventListener("click", () => $("fileInput").click());
 $("fileInput").addEventListener("change", onFilePicked);
+$("wormholeBtn").addEventListener("click", () => window.open(BIG_FILE_URL, "_blank", "noopener"));
+$("shareLinkBtn").addEventListener("click", shareLink);
+$("bigfileCancel").addEventListener("click", () => $("bigfile").hidden = true);
 $("againBtn").addEventListener("click", () => location.href = location.pathname);
 $("retryBtn").addEventListener("click", () => { joinRetries = 0; $("retryBtn").hidden = true; startMesh(); });
 
@@ -384,7 +428,16 @@ function joinAsMember(){
 
 /* ================= roster -> media mesh ================= */
 function onRoster(members){
+  // AIDEV-NOTE: shared links (unlike file payloads) are re-sent to people who
+  // join later — each author delivers their own links to newcomers, and
+  // receivers dedupe by URL.
+  const newcomers = Object.keys(members)
+    .filter(id => id !== mediaPeer.id && !(id in knownMembers));
   knownMembers = members;
+  if (myLinks.length){
+    for (const id of newcomers)
+      for (const item of myLinks) sendLinkTo(id, item);
+  }
   // connect to newcomers
   for (const id of Object.keys(members)){
     if (id === mediaPeer.id) continue;
@@ -548,10 +601,7 @@ async function onFilePicked(){
   const f = $("fileInput").files[0];
   $("fileInput").value = "";
   if (!f) return;
-  if (f.size > MAX_FILE_MB * 1024 * 1024){
-    status("Too big — files up to " + MAX_FILE_MB + " MB only.");
-    return;
-  }
+  if (f.size > MAX_FILE_MB * 1024 * 1024){ openBigFile(f.name); return; }
   const others = Object.keys(knownMembers).filter(id => id !== mediaPeer.id);
   if (!others.length){ status("No one else is in the call yet."); return; }
   status("Sending " + f.name + "…");
@@ -565,11 +615,67 @@ async function onFilePicked(){
 }
 
 function onFileMsg(fromId, msg){
-  if (!msg || msg.t !== "file" || !msg.data) return;
-  const blob = new Blob([msg.data], { type: msg.mime || "application/octet-stream" });
+  if (!msg) return;
   const who = knownMembers[fromId] || "Someone";
+  if (msg.t === "link"){
+    if (typeof msg.url !== "string" || !/^https:\/\//i.test(msg.url) || seenLinks.has(msg.url)) return;
+    seenLinks.add(msg.url);
+    addLinkItem(String(msg.name || "shared link"), msg.url, who);
+    status(who + " shared a link");
+    return;
+  }
+  if (msg.t !== "file" || !msg.data) return;
+  const blob = new Blob([msg.data], { type: msg.mime || "application/octet-stream" });
   addFileItem(msg.name || "file", msg.mime || "", blob, who);
   status(who + " shared " + (msg.name || "a file"));
+}
+
+/* ---- big files: hand off to an E2EE expiring-link service ---- */
+function openBigFile(name){
+  bigFileName = name;
+  $("bigfileText").textContent = "";
+  const b = document.createElement("b");
+  b.textContent = name;
+  $("bigfileText").append(b, " is too big to send directly (over " + MAX_FILE_MB + " MB).");
+  $("linkInput").value = "";
+  $("linkErr").textContent = "";
+  $("bigfile").hidden = false;
+}
+
+function shareLink(){
+  const url = $("linkInput").value.trim();
+  if (!/^https:\/\/\S+$/i.test(url)){
+    $("linkErr").textContent = "That does not look like a link — it should start with https://";
+    return;
+  }
+  $("bigfile").hidden = true;
+  const item = { url, name: bigFileName || "shared link" };
+  myLinks.push(item);
+  seenLinks.add(url);
+  for (const id of Object.keys(knownMembers)){
+    if (id !== mediaPeer.id) sendLinkTo(id, item);
+  }
+  addLinkItem(item.name, url, "You");
+  status("Link shared with everyone");
+}
+
+function sendLinkTo(id, item){
+  getDataConn(id, conn => {
+    try{ conn.send({ t:"link", url: item.url, name: item.name }); }catch(e){}
+  });
+}
+
+function addLinkItem(name, url, from){
+  const a = document.createElement("a");
+  a.className = "fitem";
+  a.href = url; a.target = "_blank"; a.rel = "noopener";
+  const d = document.createElement("div");
+  d.className = "fdoc"; d.textContent = "🔗";
+  const s = document.createElement("span");
+  s.textContent = (from ? from + ": " : "") + name;
+  a.append(d, s);
+  $("filesTray").appendChild(a);
+  $("filesTray").hidden = false;
 }
 
 function addFileItem(name, mime, blob, from){


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds three in-call features plus a big-file path to `family-multi-chat`, keeping the tool a single static HTML file with no backend and no new dependencies (background blur intentionally left out — it would need a ~2–3 MB CDN model and heavy client CPU).

## Features

- **Send photo/file** — pictures and documents go directly peer-to-peer over PeerJS data connections (encrypted, never through a server). Images appear as tappable thumbnails, documents as download links, in a tray above the call buttons. 25 MB per-file cap (`MAX_FILE_MB`); the sender uploads one copy per participant, matching the mesh design.
- **Big files (>25 MB)** — instead of refusing, a guided overlay opens [Wormhole](https://wormhole.app) (E2EE, no account, up to 10 GB, links expire in 24 h): upload once there, paste the link back, and it is broadcast over the existing data connections into everyone's tray. Links are re-delivered to people who join later (receivers dedupe by URL), and downloads keep working after the call ends. Only the link travels through the call; the decryption key stays in the URL fragment. Service configurable via `BIG_FILE_URL`.
- **Share screen** — `getDisplayMedia`, desktop browsers only; the button is hidden where unsupported (phones/tablets), though everyone can still watch. Sent high-res at 5 fps (`SCREEN_MEDIA`) so text stays readable at camera-like bandwidth. Swapped in/out with `RTCRtpSender.replaceTrack()`, so the call is never interrupted; the browser's native "Stop sharing" button is also handled.
- **Flip camera** — front/back toggle via `facingMode`, shown only when the device has more than one camera. Stops the current camera before opening the other one (iPhones refuse two live cameras) and recovers the original camera if the switch fails.

Supporting changes: wide frames (screen shares) letterbox instead of cropping so text is readable; the tile grid scrolls instead of pushing the control bar off-screen; `hangUp` cleans up the new tracks and data connections; README documents the features, the new config knobs, and the file-privacy model.

## Testing

Automated smoke tests with headless Chrome (real PeerJS Cloud signaling, fake media devices), all passing:

- Two-way call established, both remote videos playing
- PNG sent Alice→Bob, received, thumbnail decodes, correct sender label
- Screen share visible remotely (letterboxed), camera restored after stop
- Flip camera keeps a live outgoing track and the local tile resumes playing
- A 26 MB file opens the big-file overlay instead of sending; invalid links are rejected inline; a valid link reaches Bob's tray with the right label/target, a late-joining third peer receives it too, no duplicates, and small files still send directly
- Peer leave removes the tile; hang-up works

Not covered by automation (platform-dependent): real phone front/back camera switching and iOS behavior — worth a quick manual check on a phone after deploy.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-25d6dcc3-6687-40d7-8c04-6c82f7ce96b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-25d6dcc3-6687-40d7-8c04-6c82f7ce96b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

