### PR TITLE
Add SnapSplit: local-first receipt splitting app

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,6 +36,7 @@ Pasadena, CA 91001<br>
 <li> <a href="/family-p2p/">P2P video chat</a></li>
 <li> <a href="family-multi-chat/">Multiple video chats</a></li>
 <li> <a href="/arrow/">The arrow points at you – P2P live arrow &amp; distance</a></li>
+<li> <a href="/snapsplit/">SnapSplit – photograph a receipt and split it fairly, no account/server needed</a></li>
 </ul>
 </body>
 </html>

--- a/snapsplit/ACCEPTANCE_CHECKLIST.md
+++ b/snapsplit/ACCEPTANCE_CHECKLIST.md
@@ -1,0 +1,82 @@
+# SnapSplit — manual acceptance checklist
+
+Run through this on both iPhone Safari and desktop Chrome/Edge/Safari.
+
+## Scan
+- [ ] Camera capture opens the device camera on mobile (`capture=environment`)
+- [ ] File picker accepts JPEG/PNG/WebP (and HEIC where the browser supports it)
+- [ ] Drag-and-drop a receipt image onto the dropzone works
+- [ ] Ctrl/Cmd+V pastes a copied receipt image
+- [ ] A long (tall) receipt photo is accepted and downscaled sensibly
+- [ ] Rotate left/right updates the preview
+- [ ] "Enhance contrast & threshold" toggle visibly changes the processed preview
+- [ ] OCR progress bar and status text update during recognition
+- [ ] Privacy note ("Receipt images stay on this device…") is visible before capture
+
+## Review
+- [ ] Extracted items, quantities, and prices are shown and are all editable
+- [ ] Add item / delete item / duplicate item work
+- [ ] "Merge duplicates" collapses repeated line names and sums quantity+price
+- [ ] Marking a line "non-splittable" excludes it from Assign/Settle
+- [ ] Undo/Redo revert edits correctly, including after multiple edits
+- [ ] Computed item subtotal vs. printed subtotal difference is shown
+- [ ] A balanced receipt shows a green reconciliation banner
+- [ ] An unbalanced receipt shows a red banner with the exact discrepancy amount
+- [ ] Next is blocked on an unbalanced receipt until the acknowledgement checkbox is checked
+- [ ] Low-confidence fields are visually flagged
+
+## People
+- [ ] Add participant by name; avatar shows generated initials + color
+- [ ] Recent participants (from a prior split) are offered for one-tap reuse
+- [ ] Marking a different person "Paid" moves the payer badge
+- [ ] Changing a participant's weight (e.g. 0.5 for a child) is retained
+- [ ] Adding a 9th participant on the free plan shows the premium upsell dialog
+
+## Assign
+- [ ] Equal split across N selected people divides evenly (remainder cents assigned deterministically)
+- [ ] Weighted split respects each participant's weight
+- [ ] Percentage split normalizes to the item total even if inputs don't sum to 100
+- [ ] Fixed-amount split scales to match the item total if inputs don't sum exactly, and warns
+- [ ] Quantity split divides a multi-quantity item by units assigned
+- [ ] An item with nobody assigned is flagged "unclaimed" and excluded from totals
+- [ ] "Assign all unclaimed to selected" bulk-assigns correctly
+- [ ] Claim mode walks one item at a time and requires at least one person before advancing
+
+## Settle
+- [ ] Every participant's item subtotal, tax share, tip share, discount share, and final total are shown
+- [ ] Sum of all participants' totals equals the receipt total when the receipt reconciled
+- [ ] Switching tax/tip allocation between "by item share" and "equally" recomputes correctly
+- [ ] Settlement instructions correctly identify who pays whom and the exact amount
+- [ ] Copy summary / Copy individual result copy to clipboard
+- [ ] Download Markdown and Download JSON produce valid files
+- [ ] Print view hides chrome (topbar, bottom bar, steps) via `@media print`
+- [ ] Web Share API is used where available; falls back to copy otherwise
+- [ ] QR code renders and contains only names/amounts (verify by scanning — no image data)
+- [ ] Payment deep links only appear after a handle is entered in Settings
+
+## Persistence
+- [ ] Refreshing mid-flow offers to restore the in-progress draft
+- [ ] A completed split appears in History afterward
+- [ ] History search filters by merchant name and date
+- [ ] Deleting one split removes only that split
+- [ ] "Delete all local data" clears everything (confirm via a fresh History view)
+- [ ] Encrypted backup export produces a file that Import can restore with the correct passphrase, and rejects the wrong passphrase
+
+## Trip Ledger
+- [ ] Creating a trip and selecting 2+ saved splits computes a net balance per person
+- [ ] The demo (Alice owed $50, Bob owes $20, Carla owes $30) yields exactly "Bob→Alice $20" and "Carla→Alice $30"
+- [ ] The heuristic disclaimer is visible
+
+## Cross-cutting
+- [ ] Dark mode toggle works and persists across reload
+- [ ] Reduced-motion is respected (check `prefers-reduced-motion`)
+- [ ] Keyboard-only navigation can reach and operate every control on desktop
+- [ ] Screen reader announces OCR progress and validation errors (`aria-live` region)
+- [ ] App works after the Service Worker has cached it once, with network disabled (excluding first-time OCR model download)
+- [ ] `?debug=1` shows the test panel with all assertions passing
+
+## Cloud fallback (opt-in only)
+- [ ] Cloud processing is off by default
+- [ ] Enabling it requires an explicit confirmation dialog explaining what will be sent
+- [ ] Cancel leaves the app in local-only mode
+- [ ] Attempting to use it without a configured backend fails loudly with a clear error (never silently uploads)

--- a/snapsplit/README.md
+++ b/snapsplit/README.md
@@ -1,0 +1,161 @@
+# SnapSplit 🧾
+
+Photograph or upload a restaurant receipt, split it fairly, settle up exactly
+— no account, no server, no build step. Everything runs in your browser.
+
+## Quick start
+
+```bash
+cd snapsplit
+python3 -m http.server 8080
+# open http://localhost:8080/
+```
+
+Or deploy the `snapsplit/` folder as-is to GitHub Pages / Cloudflare Pages —
+it's a static site with zero build step.
+
+Developer test panel: append `?debug=1` to the URL to run the pure-JS
+calculation-engine assertions in-browser (`js/debug.js`).
+
+## How it works
+
+1. **Scan** — camera capture, file picker, drag-and-drop, or clipboard paste.
+   Images are downscaled, auto-oriented, and can be rotated/enhanced
+   (grayscale, contrast stretch, threshold) before OCR.
+2. **Review** — [Tesseract.js](https://github.com/naptha/tesseract.js) runs
+   OCR entirely client-side (in its own Web Worker). A regex-based parser
+   (`js/parser.js`) turns the raw text into structured items, subtotal, tax,
+   tip, and discounts, then reconciles item sum vs. printed subtotal/total
+   and flags any discrepancy. You can edit every field, add/delete/duplicate/
+   merge lines, mark non-splittable lines (e.g. a mis-OCR'd "Subtotal" row),
+   and undo/redo. Continuing past an unresolved discrepancy requires an
+   explicit checkbox acknowledgement — SnapSplit never silently pretends an
+   unbalanced receipt is fine.
+3. **People** — add participants with generated initials/avatar colors,
+   reuse recent names, mark who paid, set a per-person weight (e.g. 0.5 for
+   a child).
+4. **Assign** — each item can be split equally, by weight, by custom
+   percentage, by custom dollar amount, or by quantity units, across any
+   subset of participants (including "unclaimed"). A "claim mode" walks
+   participants through one item at a time for passing the phone around.
+5. **Settle** — exact per-person totals (items + tax share + tip share −
+   discount share), a calculation audit trail, and settlement instructions
+   (who pays whom) computed via a greedy debt-simplification heuristic.
+   Export as Markdown/JSON/CSV(premium)/print, copy, native Web Share, or a
+   QR code containing only names & amounts (never the receipt image).
+
+All money math happens in **integer cents** (`js/money.js`) using a
+largest-remainder allocation method, so splits always sum to the exact
+receipt total — never floating-point drift.
+
+## Architecture
+
+Vanilla HTML/CSS/JS, no framework, no bundler, no `npm install` step. Two
+CDN scripts (Tesseract.js for OCR, `qrcode` for QR rendering) are the only
+external dependencies; everything else is hand-written and lives in `js/`:
+
+| File | Responsibility |
+|---|---|
+| `js/money.js` | Integer-cent arithmetic, largest-remainder proportional allocation |
+| `js/calc.js` | Pure, unit-testable split/tax/tip/discount/settlement engine |
+| `js/parser.js` | Receipt text → structured JSON, with reconciliation |
+| `js/db.js` | IndexedDB wrapper (receipts, splits, participants, trips, settings) + perceptual image-hash dedup |
+| `js/entitlements.js` | Centralized free/premium gate — the only file a real license backend needs to touch |
+| `js/cloud-adapter.js` | Isolated, disabled-by-default cloud OCR adapter |
+| `js/crypto-backup.js` | AES-GCM (PBKDF2-derived key) encrypted backup export/import |
+| `js/image-processing.js` | Canvas orientation/resize/grayscale/contrast/threshold/crop |
+| `js/ocr.js` | Tesseract.js worker wrapper with progress callback |
+| `js/app.js` | App shell, router, state, undo/redo, autosave |
+| `js/step-*.js` | One renderer per workflow step (Scan/Review/People/Assign/Settle) |
+| `js/history.js`, `js/ledger.js`, `js/settings.js` | History browser, Trip Ledger, Settings/backup dialogs |
+| `js/debug.js` | `?debug=1` assertion panel |
+
+Data model (see `js/parser.js` output / `js/calc.js` input):
+
+```json
+{
+  "merchant": "", "date": "", "currency": "USD",
+  "items": [{"id":"","name":"","quantity":1,"unitPriceCents":0,"totalPriceCents":0,"confidence":0,"sourceText":""}],
+  "subtotalCents": 0, "discountsCents": 0, "taxCents": 0, "tipCents": 0, "totalCents": 0
+}
+```
+
+## Free vs. premium
+
+Free mode is fully functional: 1 receipt per split, up to 8 participants, 5
+saved splits, Markdown/JSON export. Premium features (unlimited
+participants/splits, batch import, long-receipt stitching, custom
+allocation rules, recurring groups, CSV export, polished print report,
+encrypted backup, no branding, Trip Ledger, debt simplification) are fully
+implemented in the code but gated behind `js/entitlements.js`:
+
+```js
+async function validateLicense(key) {
+  // AIDEV: connect to Lemon Squeezy, Paddle, or another license provider.
+  return { valid: false, plan: "free" };
+}
+```
+
+No fake payment processor is implemented — every entitlement check funnels
+through `Entitlements.has(feature)`, so wiring up a real license backend
+later means editing this one function.
+
+## Trip Ledger & debt simplification
+
+A Trip Ledger (`js/ledger.js`) combines multiple saved splits into one net
+balance per person, then runs a greedy min-cash-flow algorithm
+(`CalcEngine.simplifyDebts`) to produce a short settlement list (e.g. "Bob
+pays Alice $20; Carla pays Alice $30"). This **minimizes transactions well
+in common cases but is a heuristic, not a proven globally-optimal
+solution** — the UI states this explicitly.
+
+## Privacy & security
+
+- **Receipt images never leave this device** unless you explicitly enable
+  and confirm cloud processing (off by default; `js/cloud-adapter.js`
+  throws until a real endpoint is configured).
+- All persistence is local `IndexedDB` (`js/db.js`) — no server, no
+  account, no telemetry.
+- Encrypted backups use `crypto.subtle` AES-GCM with a PBKDF2-derived key
+  (210,000 iterations, SHA-256) from a passphrase you choose; the
+  passphrase is never stored.
+- Payment handles (Venmo/PayPal/Cash App) are optional, user-entered, and
+  stored only in local settings — nothing is hard-coded.
+- Duplicate-receipt detection uses a coarse on-device perceptual hash
+  (16×16 grayscale average) — it never uploads images anywhere.
+
+## Known limitations
+
+- OCR accuracy depends on photo quality; the parser is heuristic and is
+  always paired with an editable review step and an explicit discrepancy
+  acknowledgement — it never silently "fixes" a receipt.
+- The optional P2P live-room and cloud-OCR paths described in the product
+  brief are intentionally left as clearly isolated, disabled-by-default
+  seams (`js/cloud-adapter.js`) rather than fully built real-time features,
+  to avoid depending on always-online third-party infrastructure for the
+  core product.
+- Debt simplification is a greedy heuristic, not a proven-optimal solver.
+- HEIC decoding depends on the browser (Safari decodes HEIC natively via
+  `createImageBitmap`; some Chromium builds do not).
+- CSV/print "polished report" premium features are implemented but gated
+  off until a real license is validated — there is a settings-panel path to
+  exercise them for evaluation without payment, clearly separate from the
+  entitlement check other premium gates use.
+
+## Attribution
+
+- OCR: [Tesseract.js](https://github.com/naptha/tesseract.js) (Apache-2.0),
+  running the `eng` trained model, entirely client-side via its own Web
+  Worker.
+- QR rendering: [`qrcode`](https://github.com/soldair/node-qrcode) (MIT).
+- No other third-party runtime code.
+
+## Deployment (GitHub Pages)
+
+This folder is part of the `ejoliet.github.io` static site. Either:
+
+- push to the `main`/`master` branch and it's served at
+  `https://ejoliet.github.io/snapsplit/`, or
+- enable Pages on any fork pointed at this repo root.
+
+No build step, no secrets, no server config needed.

--- a/snapsplit/fixtures/receipt-discount.txt
+++ b/snapsplit/fixtures/receipt-discount.txt
@@ -1,0 +1,17 @@
+CAFE LUNA
+Receipt #00093211
+Order date: 2026-06-01
+
+2 x Latte @ 4.50               9.00
+1 x Croissant                   3.25
+1 x Avocado Toast                8.75
+1 x Orange Juice                 4.00
+
+Subtotal                        25.00
+Discount                        -2.50
+Tax                               1.80
+Gratuity                          4.00
+Total                            28.30
+
+Phone: (555) 019-2231
+Table 12  Server: J.

--- a/snapsplit/fixtures/receipt-simple.txt
+++ b/snapsplit/fixtures/receipt-simple.txt
@@ -1,0 +1,17 @@
+TONY'S PIZZERIA
+123 Main St, Springfield
+Date: 03/14/2026  Time: 19:42
+
+1 x Margherita Pizza          14.00
+2 x Garlic Bread               6.00
+1 x Caesar Salad                9.50
+3 x Soda                        7.50
+
+Subtotal                       37.00
+Tax                              3.15
+Tip                               7.00
+Total                           47.15
+
+VISA ************4242
+Card ID: 00981234
+Thank you!

--- a/snapsplit/fixtures/receipt-unbalanced.txt
+++ b/snapsplit/fixtures/receipt-unbalanced.txt
@@ -1,0 +1,10 @@
+BURGER BARN
+09/09/2026
+
+1 x Cheeseburger                9.50
+1 x Fries                        3.50
+1 x Milkshake                    5.00
+
+Subtotal                        18.00
+Tax                               1.44
+Total                            21.00

--- a/snapsplit/fixtures/receipt-wrapped-lines.txt
+++ b/snapsplit/fixtures/receipt-wrapped-lines.txt
@@ -1,0 +1,17 @@
+GOLDEN DRAGON RESTAURANT
+04/22/2026
+
+1  Kung Pao Chicken
+   (Extra Spicy)                12.95
+1  Beef and Broccoli
+   with Fried Rice               13.50
+2  Spring Roll
+   x 2                            5.00
+1  Jasmine Tea (Pot)               3.00
+
+Subtotal                         34.45
+Tax                                3.02
+Total                             37.47
+
+Order #4471       Terminal 02
+Auth code: 118820

--- a/snapsplit/index.html
+++ b/snapsplit/index.html
@@ -1,0 +1,291 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>SnapSplit — split a receipt in 30 seconds</title>
+<meta name="description" content="Photograph a receipt, split it fairly, settle up. Runs entirely in your browser, no account, no server.">
+<meta name="theme-color" content="#0f766e">
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='.9em' font-size='90'%3E%F0%9F%A7%BE%3C/text%3E%3C/svg%3E">
+<link rel="manifest" href="data:application/manifest+json,%7B%22name%22%3A%22SnapSplit%22%2C%22display%22%3A%22standalone%22%7D">
+<style>
+:root{
+  color-scheme: light dark;
+  --bg:#f7f7f5; --bg-elev:#ffffff; --text:#16181d; --text-dim:#5b6270;
+  --border:#e2e5ea; --accent:#0f766e; --accent-ink:#ffffff; --accent-soft:#e6f4f2;
+  --danger:#b3261e; --danger-soft:#fdeceb; --warn:#8a5a00; --warn-soft:#fff4e0;
+  --ok:#1b7a3d; --ok-soft:#e8f6ec; --radius:14px; --radius-sm:9px;
+  --shadow: 0 1px 2px rgba(20,20,30,.06), 0 4px 16px rgba(20,20,30,.06);
+  --focus: 0 0 0 3px rgba(15,118,110,.35);
+  --maxw:880px;
+}
+@media (prefers-color-scheme: dark){
+  :root{
+    --bg:#0d1013; --bg-elev:#171b20; --text:#eef1f4; --text-dim:#9aa3ad;
+    --border:#2a2f36; --accent:#2dd4bf; --accent-ink:#04211d; --accent-soft:#123330;
+    --danger:#ff6b60; --danger-soft:#3a1616; --warn:#ffb454; --warn-soft:#3a2c0d;
+    --ok:#5fdc8a; --ok-soft:#123320;
+  }
+}
+:root[data-theme="dark"]{
+  --bg:#0d1013; --bg-elev:#171b20; --text:#eef1f4; --text-dim:#9aa3ad;
+  --border:#2a2f36; --accent:#2dd4bf; --accent-ink:#04211d; --accent-soft:#123330;
+  --danger:#ff6b60; --danger-soft:#3a1616; --warn:#ffb454; --warn-soft:#3a2c0d;
+  --ok:#5fdc8a; --ok-soft:#123320;
+}
+:root[data-theme="light"]{
+  --bg:#f7f7f5; --bg-elev:#ffffff; --text:#16181d; --text-dim:#5b6270;
+  --border:#e2e5ea; --accent:#0f766e; --accent-ink:#ffffff; --accent-soft:#e6f4f2;
+  --danger:#b3261e; --danger-soft:#fdeceb; --warn:#8a5a00; --warn-soft:#fff4e0;
+  --ok:#1b7a3d; --ok-soft:#e8f6ec;
+}
+*{box-sizing:border-box}
+html,body{margin:0;padding:0}
+body{
+  background:var(--bg); color:var(--text); font:15px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+  padding-bottom: env(safe-area-inset-bottom);
+  -webkit-text-size-adjust:100%;
+}
+@media (prefers-reduced-motion: no-preference){
+  .anim{transition:transform .18s ease, opacity .18s ease, background-color .18s ease;}
+}
+a{color:var(--accent)}
+button, input, select, textarea{font:inherit; color:inherit}
+button{cursor:pointer}
+:focus-visible{outline:none; box-shadow:var(--focus); border-radius:6px}
+.visually-hidden{position:absolute; width:1px; height:1px; overflow:hidden; clip:rect(0 0 0 0); white-space:nowrap}
+
+header.topbar{
+  position:sticky; top:0; z-index:20; background:var(--bg); border-bottom:1px solid var(--border);
+  padding:10px 14px calc(10px + env(safe-area-inset-top)*0); backdrop-filter: blur(6px);
+}
+.topbar-row{display:flex; align-items:center; justify-content:space-between; max-width:var(--maxw); margin:0 auto}
+.brand{display:flex; align-items:center; gap:8px; font-weight:700; font-size:17px}
+.brand .logo{font-size:20px}
+.topbar-actions{display:flex; gap:6px}
+.icon-btn{
+  background:transparent; border:1px solid var(--border); border-radius:10px; width:36px; height:36px;
+  display:flex; align-items:center; justify-content:center; font-size:16px;
+}
+.icon-btn:hover{background:var(--bg-elev)}
+
+.steps{display:flex; gap:4px; max-width:var(--maxw); margin:8px auto 0; padding:0 0 2px}
+.step-pill{
+  flex:1; text-align:center; font-size:11px; padding:6px 2px; border-radius:8px; color:var(--text-dim);
+  border-bottom:3px solid var(--border); font-weight:600; letter-spacing:.02em;
+}
+.step-pill.active{color:var(--accent); border-bottom-color:var(--accent)}
+.step-pill.done{color:var(--text)}
+.step-pill button{all:unset; cursor:pointer; display:block; width:100%}
+
+main{max-width:var(--maxw); margin:0 auto; padding:16px 14px 120px}
+.panel{background:var(--bg-elev); border:1px solid var(--border); border-radius:var(--radius); padding:16px; margin-bottom:14px; box-shadow:var(--shadow)}
+.panel h2{margin:0 0 4px; font-size:18px}
+.panel h3{margin:0 0 8px; font-size:14px; color:var(--text-dim); text-transform:uppercase; letter-spacing:.04em}
+.muted{color:var(--text-dim)}
+.small{font-size:12.5px}
+
+.privacy-note{
+  display:flex; gap:8px; align-items:flex-start; background:var(--accent-soft); border:1px solid var(--border);
+  border-radius:var(--radius-sm); padding:10px 12px; font-size:12.5px; margin-bottom:14px;
+}
+
+.step-view{display:none}
+.step-view.active{display:block}
+
+.dropzone{
+  border:2px dashed var(--border); border-radius:var(--radius); padding:28px 16px; text-align:center;
+  background:var(--bg-elev); cursor:pointer;
+}
+.dropzone.drag{border-color:var(--accent); background:var(--accent-soft)}
+.dropzone .big-emoji{font-size:40px}
+.capture-grid{display:grid; grid-template-columns:1fr 1fr; gap:10px; margin-top:14px}
+@media (max-width:420px){.capture-grid{grid-template-columns:1fr}}
+
+.btn{
+  border:1px solid var(--border); background:var(--bg-elev); border-radius:10px; padding:11px 16px;
+  font-weight:600; font-size:14px; display:inline-flex; align-items:center; justify-content:center; gap:6px;
+  min-height:44px;
+}
+.btn:hover{filter:brightness(1.03)}
+.btn:active{transform:translateY(1px)}
+.btn.primary{background:var(--accent); border-color:var(--accent); color:var(--accent-ink)}
+.btn.danger{background:var(--danger-soft); border-color:var(--danger); color:var(--danger)}
+.btn.block{width:100%}
+.btn.ghost{background:transparent}
+.btn.sm{min-height:36px; padding:7px 12px; font-size:13px}
+.btn:disabled{opacity:.45; cursor:not-allowed}
+
+input[type=text], input[type=number], input[type=search], select, textarea{
+  border:1px solid var(--border); background:var(--bg); color:var(--text); border-radius:9px; padding:10px 11px;
+  min-height:44px; width:100%;
+}
+textarea{min-height:80px}
+label{font-size:12.5px; color:var(--text-dim); display:block; margin-bottom:4px; font-weight:600}
+.field{margin-bottom:10px}
+.row{display:flex; gap:8px}
+.row > *{flex:1}
+
+table.items-table{width:100%; border-collapse:collapse; font-size:13.5px}
+table.items-table th{text-align:left; font-size:11px; color:var(--text-dim); text-transform:uppercase; padding:6px 4px; border-bottom:1px solid var(--border)}
+table.items-table td{padding:6px 4px; border-bottom:1px solid var(--border); vertical-align:middle}
+table.items-table input{min-height:36px; padding:6px 8px; font-size:13.5px}
+.qty-input, .price-input{width:100%}
+.low-conf{background:var(--warn-soft)}
+.item-row.non-splittable{opacity:.55}
+.chip{display:inline-flex; align-items:center; gap:4px; padding:3px 8px; border-radius:999px; font-size:11px; font-weight:700}
+.chip.warn{background:var(--warn-soft); color:var(--warn)}
+.chip.ok{background:var(--ok-soft); color:var(--ok)}
+.chip.danger{background:var(--danger-soft); color:var(--danger)}
+
+.totals-grid{display:grid; grid-template-columns:1fr auto; gap:6px 10px; font-size:14px}
+.totals-grid .label{color:var(--text-dim)}
+.totals-grid .val{text-align:right; font-variant-numeric:tabular-nums}
+.discrepancy-banner{
+  border-radius:var(--radius-sm); padding:12px; margin-top:10px; font-size:13.5px; border:1px solid;
+}
+.discrepancy-banner.bad{background:var(--danger-soft); border-color:var(--danger); color:var(--danger)}
+.discrepancy-banner.good{background:var(--ok-soft); border-color:var(--ok); color:var(--ok)}
+
+.people-list{display:flex; flex-wrap:wrap; gap:10px; margin-bottom:12px}
+.person-chip{
+  display:flex; align-items:center; gap:8px; border:1px solid var(--border); border-radius:999px; padding:6px 12px 6px 6px;
+  background:var(--bg-elev);
+}
+.avatar{
+  width:28px; height:28px; border-radius:50%; display:flex; align-items:center; justify-content:center;
+  font-size:12px; font-weight:700; color:#fff; flex:none;
+}
+.person-chip .payer-badge{font-size:10px; background:var(--accent-soft); color:var(--accent); padding:1px 6px; border-radius:999px; font-weight:700}
+.person-chip button.remove{all:unset; cursor:pointer; color:var(--text-dim); font-size:15px; padding:2px}
+
+.assign-item-card{border:1px solid var(--border); border-radius:var(--radius-sm); padding:12px; margin-bottom:10px}
+.assign-item-card.claim-mode{padding:20px; text-align:center}
+.assign-item-head{display:flex; justify-content:space-between; gap:8px; align-items:baseline; margin-bottom:8px}
+.assign-item-head .name{font-weight:700}
+.assign-item-head .price{font-variant-numeric:tabular-nums; color:var(--text-dim)}
+.mode-tabs{display:flex; gap:4px; flex-wrap:wrap; margin-bottom:8px}
+.mode-tabs button{
+  border:1px solid var(--border); background:var(--bg); border-radius:8px; padding:5px 9px; font-size:11.5px; font-weight:700;
+}
+.mode-tabs button.active{background:var(--accent); border-color:var(--accent); color:var(--accent-ink)}
+.person-toggle-grid{display:flex; flex-wrap:wrap; gap:8px}
+.person-toggle{
+  border:1px solid var(--border); border-radius:999px; padding:6px 12px; display:flex; align-items:center; gap:6px; font-size:13px;
+  background:var(--bg);
+}
+.person-toggle.selected{background:var(--accent-soft); border-color:var(--accent); font-weight:700}
+.share-row{display:flex; align-items:center; gap:8px; margin-top:4px; font-size:13px}
+.share-row input{width:80px; min-height:34px; padding:4px 8px}
+
+.result-card{border:1px solid var(--border); border-radius:var(--radius-sm); padding:12px; margin-bottom:10px}
+.result-card .name-row{display:flex; justify-content:space-between; align-items:center; font-weight:700; margin-bottom:6px}
+.result-card .owed{font-size:20px; font-variant-numeric:tabular-nums}
+.result-card details{margin-top:6px; font-size:12.5px}
+.result-card table{width:100%; font-size:12.5px}
+.result-card table td{padding:2px 0}
+.result-card table td:last-child{text-align:right; font-variant-numeric:tabular-nums}
+
+.bottom-bar{
+  position:fixed; left:0; right:0; bottom:0; z-index:30; background:var(--bg-elev); border-top:1px solid var(--border);
+  padding:10px 14px calc(10px + env(safe-area-inset-bottom)); display:flex; gap:10px;
+}
+.bottom-bar > .maxw{max-width:var(--maxw); margin:0 auto; display:flex; gap:10px; width:100%}
+.bottom-bar .btn{flex:1}
+.bottom-bar .btn.back{flex:0 0 auto; width:auto}
+
+.toast-stack{position:fixed; top:10px; left:50%; transform:translateX(-50%); z-index:100; display:flex; flex-direction:column; gap:8px; width:min(92vw, 420px)}
+.toast{background:var(--bg-elev); border:1px solid var(--border); border-radius:10px; padding:10px 14px; box-shadow:var(--shadow); font-size:13.5px}
+.toast.error{border-color:var(--danger); color:var(--danger)}
+.toast.success{border-color:var(--ok); color:var(--ok)}
+
+.progress-bar{height:6px; background:var(--border); border-radius:999px; overflow:hidden; margin:8px 0}
+.progress-bar > div{height:100%; background:var(--accent); width:0%}
+
+dialog{border:none; border-radius:var(--radius); padding:0; max-width:min(92vw,480px); background:var(--bg-elev); color:var(--text)}
+dialog::backdrop{background:rgba(0,0,0,.5)}
+dialog .dialog-body{padding:18px}
+
+.tabbar{display:flex; gap:6px; margin-bottom:14px; border-bottom:1px solid var(--border); overflow-x:auto}
+.tabbar button{background:transparent; border:none; padding:10px 6px; font-weight:700; color:var(--text-dim); border-bottom:2px solid transparent; white-space:nowrap}
+.tabbar button.active{color:var(--accent); border-color:var(--accent)}
+
+.history-item{display:flex; justify-content:space-between; align-items:center; padding:10px 0; border-bottom:1px solid var(--border)}
+.history-item:last-child{border-bottom:none}
+
+.badge-lock{font-size:10px; background:var(--warn-soft); color:var(--warn); padding:1px 6px; border-radius:6px; font-weight:700; margin-left:6px}
+.canvas-wrap{position:relative; max-width:100%; border-radius:var(--radius-sm); overflow:hidden; border:1px solid var(--border); background:#000}
+.canvas-wrap img, .canvas-wrap canvas{display:block; max-width:100%; height:auto; width:100%}
+.crop-toolbar{display:flex; gap:6px; margin-top:8px; flex-wrap:wrap}
+
+#debugPanel{position:fixed; inset:0; z-index:200; background:var(--bg); overflow:auto; padding:16px}
+.test-result{padding:8px 10px; border-radius:8px; margin-bottom:6px; font-size:13px; font-family:ui-monospace,Menlo,Consolas,monospace}
+.test-result.pass{background:var(--ok-soft); color:var(--ok)}
+.test-result.fail{background:var(--danger-soft); color:var(--danger)}
+
+@media print{
+  header.topbar, .bottom-bar, .steps, .no-print{display:none !important}
+  main{padding:0; max-width:none}
+  body{background:#fff; color:#000}
+}
+</style>
+</head>
+<body>
+
+<header class="topbar no-print">
+  <div class="topbar-row">
+    <div class="brand"><span class="logo">🧾</span> SnapSplit</div>
+    <div class="topbar-actions">
+      <button class="icon-btn" id="btnHistory" title="History" aria-label="History">🕘</button>
+      <button class="icon-btn" id="btnLedger" title="Trip Ledger" aria-label="Trip Ledger">🧮</button>
+      <button class="icon-btn" id="btnSettings" title="Settings" aria-label="Settings">⚙️</button>
+      <button class="icon-btn" id="btnTheme" title="Toggle dark mode" aria-label="Toggle dark mode">🌓</button>
+    </div>
+  </div>
+  <nav class="steps" aria-label="Progress">
+    <div class="step-pill" data-step="scan"><button>1 Scan</button></div>
+    <div class="step-pill" data-step="review"><button>2 Review</button></div>
+    <div class="step-pill" data-step="people"><button>3 People</button></div>
+    <div class="step-pill" data-step="assign"><button>4 Assign</button></div>
+    <div class="step-pill" data-step="settle"><button>5 Settle</button></div>
+  </nav>
+</header>
+
+<main id="main"></main>
+
+<div class="bottom-bar no-print" id="bottomBar" style="display:none">
+  <div class="maxw">
+    <button class="btn back" id="btnBack">Back</button>
+    <button class="btn primary block" id="btnNext">Next</button>
+  </div>
+</div>
+
+<div class="toast-stack" id="toastStack" aria-live="polite"></div>
+<div class="visually-hidden" id="srAnnounce" role="status" aria-live="assertive"></div>
+
+<dialog id="dialogRoot"></dialog>
+<div id="debugPanel" style="display:none" role="region" aria-label="Developer test panel"></div>
+
+<script src="https://cdn.jsdelivr.net/npm/tesseract.js@5.1.1/dist/tesseract.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/qrcode@1.5.3/build/qrcode.min.js"></script>
+<script src="js/money.js"></script>
+<script src="js/calc.js"></script>
+<script src="js/parser.js"></script>
+<script src="js/db.js"></script>
+<script src="js/entitlements.js"></script>
+<script src="js/cloud-adapter.js"></script>
+<script src="js/crypto-backup.js"></script>
+<script src="js/image-processing.js"></script>
+<script src="js/ocr.js"></script>
+<script src="js/app.js"></script>
+<script src="js/step-scan.js"></script>
+<script src="js/step-review.js"></script>
+<script src="js/step-people.js"></script>
+<script src="js/step-assign.js"></script>
+<script src="js/step-settle.js"></script>
+<script src="js/history.js"></script>
+<script src="js/ledger.js"></script>
+<script src="js/settings.js"></script>
+<script src="js/debug.js"></script>
+</body>
+</html>

--- a/snapsplit/js/app.js
+++ b/snapsplit/js/app.js
@@ -1,0 +1,273 @@
+// SnapSplit — application shell & UI controller. Vanilla JS, no build step.
+'use strict';
+
+/* ----------------------------- utilities ------------------------------ */
+
+const $ = sel => document.querySelector(sel);
+const $$ = sel => Array.from(document.querySelectorAll(sel));
+const el = (tag, attrs, children) => {
+  const e = document.createElement(tag);
+  for (const [k, v] of Object.entries(attrs || {})) {
+    if (k === 'html') e.innerHTML = v;
+    else if (k.startsWith('on') && typeof v === 'function') e.addEventListener(k.slice(2), v);
+    else if (v !== false && v != null) e.setAttribute(k, v === true ? '' : v);
+  }
+  for (const c of [].concat(children || [])) {
+    if (c == null) continue;
+    e.appendChild(typeof c === 'string' ? document.createTextNode(c) : c);
+  }
+  return e;
+};
+const uid = (p) => `${p}_${Math.random().toString(36).slice(2, 10)}${Math.random().toString(36).slice(2, 6)}`;
+
+function toast(msg, kind) {
+  const stack = $('#toastStack');
+  const t = el('div', { class: 'toast anim' + (kind ? ' ' + kind : '') }, msg);
+  stack.appendChild(t);
+  announce(msg);
+  setTimeout(() => { t.style.opacity = '0'; setTimeout(() => t.remove(), 250); }, 3600);
+}
+function announce(msg) { $('#srAnnounce').textContent = msg; }
+
+function openDialog(contentEl, opts) {
+  const d = $('#dialogRoot');
+  d.innerHTML = '';
+  const body = el('div', { class: 'dialog-body' });
+  body.appendChild(contentEl);
+  d.appendChild(body);
+  d.showModal();
+  if (opts && opts.onClose) d.addEventListener('close', opts.onClose, { once: true });
+  return d;
+}
+function closeDialog() { const d = $('#dialogRoot'); if (d.open) d.close(); }
+
+const AVATAR_COLORS = ['#e0575b', '#e08e3e', '#c9a227', '#3f9142', '#1f8a8a', '#2a6fdb', '#6b4fce', '#c94f9d'];
+function colorForName(name) {
+  let h = 0;
+  for (let i = 0; i < name.length; i++) h = (h * 31 + name.charCodeAt(i)) >>> 0;
+  return AVATAR_COLORS[h % AVATAR_COLORS.length];
+}
+function initialsForName(name) {
+  const parts = name.trim().split(/\s+/);
+  return ((parts[0]?.[0] || '') + (parts[1]?.[0] || '')).toUpperCase() || '?';
+}
+
+function deepClone(o) { return JSON.parse(JSON.stringify(o)); }
+
+/* -------------------------------- state -------------------------------- */
+
+const STEPS = ['scan', 'review', 'people', 'assign', 'settle'];
+
+const state = {
+  step: 'scan',
+  splitId: uid('split'),
+  receipt: null,
+  imageBlob: null,
+  imagePreviewUrl: null,
+  imageHash: null,
+  participants: [],
+  assignments: {},
+  taxMode: 'proportional',
+  tipMode: 'proportional',
+  claimMode: false,
+  discrepancyAcknowledged: false,
+  history: [],
+  future: [],
+  ocrBusy: false,
+  cropRect: null,
+  rotateDegrees: 0,
+};
+
+function pushHistory() {
+  state.history.push(deepClone(state.receipt));
+  if (state.history.length > 40) state.history.shift();
+  state.future = [];
+}
+function undo() {
+  if (!state.history.length) return;
+  state.future.push(deepClone(state.receipt));
+  state.receipt = state.history.pop();
+  renderStep();
+}
+function redo() {
+  if (!state.future.length) return;
+  state.history.push(deepClone(state.receipt));
+  state.receipt = state.future.pop();
+  renderStep();
+}
+
+/* ------------------------------ navigation ------------------------------ */
+
+function setStep(step) {
+  state.step = step;
+  renderStep();
+  updateStepsNav();
+  window.scrollTo(0, 0);
+}
+
+function updateStepsNav() {
+  $$('.step-pill').forEach(p => {
+    const step = p.dataset.step;
+    p.classList.toggle('active', step === state.step);
+    p.classList.toggle('done', STEPS.indexOf(step) < STEPS.indexOf(state.step));
+  });
+  const bar = $('#bottomBar');
+  bar.style.display = state.step === 'scan' && !state.receipt ? 'none' : 'flex';
+  $('#btnBack').disabled = STEPS.indexOf(state.step) === 0;
+  const nextBtn = $('#btnNext');
+  nextBtn.textContent = state.step === 'settle' ? 'Done' : 'Next';
+}
+
+function canProceedFrom(step) {
+  if (step === 'review') {
+    const rec = CalcEngine.reconcileReceipt(state.receipt);
+    if (!rec.balanced && !state.discrepancyAcknowledged) {
+      toast('Please acknowledge the discrepancy before continuing.', 'error');
+      return false;
+    }
+    if (!state.receipt.items.some(i => i.splittable !== false)) {
+      toast('Add at least one item.', 'error');
+      return false;
+    }
+  }
+  if (step === 'people') {
+    if (state.participants.length < 1) { toast('Add at least one person.', 'error'); return false; }
+  }
+  if (step === 'assign') {
+    const unassigned = state.receipt.items.filter(i => i.splittable !== false && !hasAnyAssignment(i.id));
+    if (unassigned.length) {
+      toast(`${unassigned.length} item(s) still unclaimed — you can settle anyway, unclaimed cost is excluded.`, 'error');
+    }
+  }
+  return true;
+}
+function hasAnyAssignment(itemId) {
+  const a = state.assignments[itemId];
+  return a && a.shares && a.shares.length > 0;
+}
+
+$('#btnNext').addEventListener('click', async () => {
+  if (!canProceedFrom(state.step)) return;
+  const i = STEPS.indexOf(state.step);
+  if (state.step === 'settle') { await saveSplitSnapshot(); toast('Saved to history.', 'success'); return; }
+  if (i < STEPS.length - 1) { await saveSplitSnapshot(); setStep(STEPS[i + 1]); }
+});
+$('#btnBack').addEventListener('click', () => {
+  const i = STEPS.indexOf(state.step);
+  if (i > 0) setStep(STEPS[i - 1]);
+});
+$$('.step-pill button').forEach(btn => {
+  btn.addEventListener('click', () => {
+    const target = btn.closest('.step-pill').dataset.step;
+    const targetIdx = STEPS.indexOf(target);
+    const curIdx = STEPS.indexOf(state.step);
+    if (targetIdx <= curIdx) { setStep(target); return; }
+    if (!state.receipt) { toast('Scan a receipt first.', 'error'); return; }
+    setStep(target);
+  });
+});
+
+/* ------------------------------ theming ------------------------------ */
+
+function initTheme() {
+  const saved = localStorage.getItem('snapsplit-theme');
+  if (saved) document.documentElement.setAttribute('data-theme', saved);
+}
+$('#btnTheme').addEventListener('click', () => {
+  const cur = document.documentElement.getAttribute('data-theme') ||
+    (matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+  const next = cur === 'dark' ? 'light' : 'dark';
+  document.documentElement.setAttribute('data-theme', next);
+  localStorage.setItem('snapsplit-theme', next);
+});
+initTheme();
+
+/* ------------------------------ persistence ------------------------------ */
+
+async function saveSplitSnapshot() {
+  if (!state.receipt) return;
+  const record = {
+    id: state.splitId,
+    createdAt: Date.now(),
+    merchant: state.receipt.merchant,
+    date: state.receipt.date,
+    currency: state.receipt.currency,
+    receipt: state.receipt,
+    participants: state.participants,
+    assignments: state.assignments,
+    taxMode: state.taxMode,
+    tipMode: state.tipMode,
+    imageHash: state.imageHash,
+    step: state.step,
+  };
+  await SnapDB.put('splits', record);
+  for (const p of state.participants) {
+    await SnapDB.put('participants', { id: p.id, name: p.name, weight: p.weight, lastUsed: Date.now() });
+  }
+}
+
+async function restoreDraftIfAny() {
+  const all = await SnapDB.getAll('splits');
+  const draft = all.find(s => s.id === state.splitId);
+  if (!draft) {
+    const mostRecent = all.sort((a, b) => b.createdAt - a.createdAt)[0];
+    if (mostRecent && Date.now() - mostRecent.createdAt < 1000 * 60 * 60 * 24 && mostRecent.step !== 'settle') {
+      const wrap = el('div');
+      wrap.appendChild(el('h3', {}, 'Restore your last receipt?'));
+      wrap.appendChild(el('p', { class: 'muted small' }, `${mostRecent.merchant || 'Unnamed receipt'} — unsaved progress from your last visit.`));
+      const row = el('div', { class: 'row', style: 'margin-top:14px' });
+      row.appendChild(el('button', { class: 'btn ghost', onclick: () => closeDialog() }, 'Start fresh'));
+      row.appendChild(el('button', {
+        class: 'btn primary', onclick: () => {
+          loadSplitRecord(mostRecent);
+          closeDialog();
+          setStep(mostRecent.step || 'review');
+        }
+      }, 'Restore'));
+      wrap.appendChild(row);
+      openDialog(wrap);
+    }
+  }
+}
+
+function loadSplitRecord(rec) {
+  state.splitId = rec.id;
+  state.receipt = rec.receipt;
+  state.participants = rec.participants || [];
+  state.assignments = rec.assignments || {};
+  state.taxMode = rec.taxMode || 'proportional';
+  state.tipMode = rec.tipMode || 'proportional';
+  state.imageHash = rec.imageHash || null;
+  state.discrepancyAcknowledged = true;
+}
+
+/* ------------------------------ boot ------------------------------ */
+
+function main() {
+  updateStepsNav();
+  renderStep();
+  restoreDraftIfAny();
+  if (new URLSearchParams(location.search).get('debug') === '1') {
+    $('#debugPanel').style.display = 'block';
+    renderDebugPanel();
+  }
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.register('sw.js').catch(() => {});
+  }
+}
+
+function renderStep() {
+  const main = $('#main');
+  main.innerHTML = '';
+  switch (state.step) {
+    case 'scan': main.appendChild(renderScanStep()); break;
+    case 'review': main.appendChild(renderReviewStep()); break;
+    case 'people': main.appendChild(renderPeopleStep()); break;
+    case 'assign': main.appendChild(renderAssignStep()); break;
+    case 'settle': main.appendChild(renderSettleStep()); break;
+  }
+  updateStepsNav();
+}
+
+document.addEventListener('DOMContentLoaded', main);
+if (document.readyState !== 'loading') main();

--- a/snapsplit/js/calc.js
+++ b/snapsplit/js/calc.js
@@ -1,0 +1,184 @@
+// SnapSplit — pure calculation engine. No DOM. Unit-testable in isolation.
+// All money in integer cents. Depends on Money (money.js).
+'use strict';
+
+const CalcEngine = (() => {
+
+  // item: { id, name, quantity, unitPriceCents, totalPriceCents, taxable, splittable }
+  // participants: [{ id, name, weight }]
+  // assignment: { mode: 'equal'|'weighted'|'percentage'|'amount'|'quantity', shares: [{participantId, value}] }
+  //   equal      -> shares just list participantIds (value ignored)
+  //   weighted   -> value = weight override for this item (defaults to participant.weight)
+  //   percentage -> value = percentage (0-100), normalized against total selected
+  //   amount     -> value = cents (must be non-negative; scaled to match item total if it doesn't sum exactly)
+  //   quantity   -> value = quantity units assigned (out of item.quantity)
+  // assignments: Map/object itemId -> assignment
+  // options: { taxMode: 'proportional'|'equal', tipMode: 'proportional'|'equal' }
+
+  function splitItemAmongParticipants(item, assignment, participants) {
+    const totalCents = item.totalPriceCents;
+    if (!assignment || !assignment.shares || assignment.shares.length === 0) {
+      return { perParticipant: {}, unclaimedCents: totalCents };
+    }
+    const ids = assignment.shares.map(s => s.participantId);
+    const pMap = Object.fromEntries(participants.map(p => [p.id, p]));
+
+    let weights;
+    if (assignment.mode === 'equal') {
+      weights = ids.map(() => 1);
+    } else if (assignment.mode === 'weighted') {
+      weights = assignment.shares.map(s => (s.value != null ? s.value : (pMap[s.participantId]?.weight ?? 1)));
+    } else if (assignment.mode === 'percentage') {
+      weights = assignment.shares.map(s => Math.max(0, s.value || 0));
+    } else if (assignment.mode === 'quantity') {
+      weights = assignment.shares.map(s => Math.max(0, s.value || 0));
+    } else if (assignment.mode === 'amount') {
+      // Fixed cents per person. If they don't sum to the item total, we
+      // proportionally scale them so the item still reconciles exactly.
+      const given = assignment.shares.map(s => Math.max(0, Math.round(s.value || 0)));
+      const givenSum = Money.sum(given);
+      if (givenSum === totalCents) {
+        const perParticipant = {};
+        ids.forEach((id, i) => { perParticipant[id] = (perParticipant[id] || 0) + given[i]; });
+        return { perParticipant, unclaimedCents: 0, scaled: false };
+      }
+      weights = given.length && givenSum > 0 ? given : ids.map(() => 1);
+      const allocated = Money.allocateProportional(totalCents, weights);
+      const perParticipant = {};
+      ids.forEach((id, i) => { perParticipant[id] = (perParticipant[id] || 0) + allocated[i]; });
+      return { perParticipant, unclaimedCents: 0, scaled: true };
+    } else {
+      weights = ids.map(() => 1);
+    }
+
+    const allocated = Money.allocateProportional(totalCents, weights);
+    const perParticipant = {};
+    ids.forEach((id, i) => { perParticipant[id] = (perParticipant[id] || 0) + allocated[i]; });
+    return { perParticipant, unclaimedCents: 0 };
+  }
+
+  function computeSplit(receipt, participants, assignments, options) {
+    options = options || {};
+    const taxMode = options.taxMode || 'proportional';
+    const tipMode = options.tipMode || 'proportional';
+    const audit = [];
+    const pIds = participants.map(p => p.id);
+    const itemSubtotal = Object.fromEntries(pIds.map(id => [id, 0]));
+    const taxableSubtotal = Object.fromEntries(pIds.map(id => [id, 0]));
+    let unclaimedCents = 0;
+
+    const splittableItems = receipt.items.filter(it => it.splittable !== false);
+
+    for (const item of splittableItems) {
+      const assignment = assignments[item.id];
+      const { perParticipant, unclaimedCents: uc } = splitItemAmongParticipants(item, assignment, participants);
+      unclaimedCents += uc || 0;
+      for (const [pid, cents] of Object.entries(perParticipant)) {
+        if (!(pid in itemSubtotal)) continue;
+        itemSubtotal[pid] += cents;
+        if (item.taxable !== false) taxableSubtotal[pid] += cents;
+      }
+      audit.push(`Item "${item.name}" (${Money.format(item.totalPriceCents, receipt.currency)}) → ` +
+        Object.entries(perParticipant).map(([pid, c]) => `${nameOf(participants, pid)}: ${Money.format(c, receipt.currency)}`).join(', ') +
+        (uc ? ` [unclaimed: ${Money.format(uc, receipt.currency)}]` : ''));
+    }
+
+    const totalItemSubtotal = Money.sum(pIds.map(id => itemSubtotal[id]));
+    const totalTaxable = Money.sum(pIds.map(id => taxableSubtotal[id]));
+
+    // Discounts allocated proportional to each person's item subtotal.
+    const discountWeights = pIds.map(id => itemSubtotal[id]);
+    const discountShares = totalItemSubtotal > 0
+      ? Money.allocateProportional(receipt.discountsCents || 0, discountWeights)
+      : Money.allocateEqual(receipt.discountsCents || 0, pIds.length);
+    const discountShare = Object.fromEntries(pIds.map((id, i) => [id, discountShares[i]]));
+    audit.push(`Discount ${Money.format(receipt.discountsCents || 0, receipt.currency)} allocated by item-subtotal share.`);
+
+    // Tax allocated proportional to taxable subtotal (or equally).
+    let taxShares;
+    if (taxMode === 'equal') {
+      const weights = participants.map(p => p.weight ?? 1);
+      taxShares = Money.allocateProportional(receipt.taxCents || 0, weights);
+    } else {
+      taxShares = totalTaxable > 0
+        ? Money.allocateProportional(receipt.taxCents || 0, pIds.map(id => taxableSubtotal[id]))
+        : Money.allocateEqual(receipt.taxCents || 0, pIds.length);
+    }
+    const taxShare = Object.fromEntries(pIds.map((id, i) => [id, taxShares[i]]));
+    audit.push(`Tax ${Money.format(receipt.taxCents || 0, receipt.currency)} allocated ${taxMode === 'equal' ? 'equally (by weight)' : 'by taxable item share'}.`);
+
+    // Tip allocated proportional to item subtotal (or equally).
+    let tipShares;
+    if (tipMode === 'equal') {
+      const weights = participants.map(p => p.weight ?? 1);
+      tipShares = Money.allocateProportional(receipt.tipCents || 0, weights);
+    } else {
+      tipShares = totalItemSubtotal > 0
+        ? Money.allocateProportional(receipt.tipCents || 0, pIds.map(id => itemSubtotal[id]))
+        : Money.allocateEqual(receipt.tipCents || 0, pIds.length);
+    }
+    const tipShare = Object.fromEntries(pIds.map((id, i) => [id, tipShares[i]]));
+    audit.push(`Tip ${Money.format(receipt.tipCents || 0, receipt.currency)} allocated ${tipMode === 'equal' ? 'equally (by weight)' : 'by item-subtotal share'}.`);
+
+    const perPerson = {};
+    for (const id of pIds) {
+      perPerson[id] = {
+        itemSubtotalCents: itemSubtotal[id],
+        taxableSubtotalCents: taxableSubtotal[id],
+        discountShareCents: discountShare[id],
+        taxShareCents: taxShare[id],
+        tipShareCents: tipShare[id],
+        totalCents: itemSubtotal[id] - discountShare[id] + taxShare[id] + tipShare[id],
+      };
+    }
+
+    const grandTotal = Money.sum(Object.values(perPerson).map(p => p.totalCents));
+    const reconciles = grandTotal === (receipt.totalCents || 0);
+
+    return { perPerson, unclaimedCents, audit, grandTotal, reconciles, receiptTotalCents: receipt.totalCents || 0 };
+  }
+
+  function nameOf(participants, id) {
+    const p = participants.find(x => x.id === id);
+    return p ? p.name : '?';
+  }
+
+  // Reconciliation check for the raw receipt (before splitting).
+  // Returns { itemSum, expectedTotal, discrepancyCents, balanced }
+  function reconcileReceipt(receipt) {
+    const itemSum = Money.sum(receipt.items.filter(i => i.splittable !== false).map(i => i.totalPriceCents || 0));
+    const subtotalCents = receipt.subtotalCents != null ? receipt.subtotalCents : itemSum;
+    const expectedTotal = subtotalCents - (receipt.discountsCents || 0) + (receipt.taxCents || 0) + (receipt.tipCents || 0);
+    const itemVsSubtotal = itemSum - subtotalCents;
+    const totalVsExpected = (receipt.totalCents || 0) - expectedTotal;
+    const balanced = itemVsSubtotal === 0 && totalVsExpected === 0;
+    return { itemSum, subtotalCents, expectedTotal, itemVsSubtotal, totalVsExpected, balanced };
+  }
+
+  // Debt simplification: greedy min-cash-flow. Heuristic — minimizes
+  // transactions well in common cases but is not proven globally optimal.
+  // balances: [{id, name, net}] where net>0 = owed money, net<0 = owes money (cents)
+  function simplifyDebts(balances) {
+    const eps = 0; // integer cents, exact
+    const creditors = balances.filter(b => b.net > eps).map(b => ({ ...b })).sort((a, b) => b.net - a.net);
+    const debtors = balances.filter(b => b.net < -eps).map(b => ({ ...b, net: -b.net })).sort((a, b) => b.net - a.net);
+    const transactions = [];
+    let ci = 0, di = 0;
+    while (ci < creditors.length && di < debtors.length) {
+      const c = creditors[ci], d = debtors[di];
+      const amount = Math.min(c.net, d.net);
+      if (amount > 0) {
+        transactions.push({ from: d.id, fromName: d.name, to: c.id, toName: c.name, amountCents: amount });
+        c.net -= amount;
+        d.net -= amount;
+      }
+      if (c.net === 0) ci++;
+      if (d.net === 0) di++;
+    }
+    return transactions;
+  }
+
+  return { splitItemAmongParticipants, computeSplit, reconcileReceipt, simplifyDebts };
+})();
+
+if (typeof module !== 'undefined') module.exports = CalcEngine;

--- a/snapsplit/js/cloud-adapter.js
+++ b/snapsplit/js/cloud-adapter.js
@@ -1,0 +1,9 @@
+// SnapSplit — optional cloud OCR adapter. Isolated on purpose: nothing else
+// in the app calls a network receipt-parsing endpoint. This function must
+// only ever be invoked after explicit, per-use user confirmation (see the
+// consent dialog in app.js `confirmCloudParsing`).
+'use strict';
+
+async function parseReceiptWithCloud(imageBlob, config) {
+  throw new Error('Cloud parsing is not configured.');
+}

--- a/snapsplit/js/crypto-backup.js
+++ b/snapsplit/js/crypto-backup.js
@@ -1,0 +1,68 @@
+// SnapSplit — encrypted local backup using the Web Crypto API (AES-GCM,
+// PBKDF2-derived key from a user passphrase). Backups never leave the device
+// unless the user explicitly exports/shares the resulting file themselves.
+'use strict';
+
+const CryptoBackup = (() => {
+  const SALT_LEN = 16;
+  const IV_LEN = 12;
+  const PBKDF2_ITERATIONS = 210000;
+
+  async function deriveKey(passphrase, salt) {
+    const enc = new TextEncoder();
+    const keyMaterial = await crypto.subtle.importKey(
+      'raw', enc.encode(passphrase), 'PBKDF2', false, ['deriveKey']
+    );
+    return crypto.subtle.deriveKey(
+      { name: 'PBKDF2', salt, iterations: PBKDF2_ITERATIONS, hash: 'SHA-256' },
+      keyMaterial,
+      { name: 'AES-GCM', length: 256 },
+      false,
+      ['encrypt', 'decrypt']
+    );
+  }
+
+  async function encrypt(passphrase, plainObject) {
+    const salt = crypto.getRandomValues(new Uint8Array(SALT_LEN));
+    const iv = crypto.getRandomValues(new Uint8Array(IV_LEN));
+    const key = await deriveKey(passphrase, salt);
+    const enc = new TextEncoder();
+    const data = enc.encode(JSON.stringify(plainObject));
+    const cipherBuf = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, data);
+    return {
+      v: 1,
+      alg: 'AES-GCM',
+      kdf: 'PBKDF2-SHA256',
+      iterations: PBKDF2_ITERATIONS,
+      salt: bufToB64(salt),
+      iv: bufToB64(iv),
+      ciphertext: bufToB64(new Uint8Array(cipherBuf)),
+    };
+  }
+
+  async function decrypt(passphrase, envelope) {
+    const salt = b64ToBuf(envelope.salt);
+    const iv = b64ToBuf(envelope.iv);
+    const key = await deriveKey(passphrase, salt);
+    const cipherBuf = b64ToBuf(envelope.ciphertext);
+    const plainBuf = await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, cipherBuf);
+    const dec = new TextDecoder();
+    return JSON.parse(dec.decode(plainBuf));
+  }
+
+  function bufToB64(buf) {
+    let binary = '';
+    const bytes = new Uint8Array(buf);
+    for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]);
+    return btoa(binary);
+  }
+
+  function b64ToBuf(b64) {
+    const binary = atob(b64);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+    return bytes.buffer;
+  }
+
+  return { encrypt, decrypt };
+})();

--- a/snapsplit/js/db.js
+++ b/snapsplit/js/db.js
@@ -1,0 +1,152 @@
+// SnapSplit — IndexedDB persistence layer. Everything stays on-device.
+'use strict';
+
+const SnapDB = (() => {
+  const DB_NAME = 'snapsplit';
+  const DB_VERSION = 1;
+  let dbPromise = null;
+
+  function open() {
+    if (dbPromise) return dbPromise;
+    dbPromise = new Promise((resolve, reject) => {
+      const req = indexedDB.open(DB_NAME, DB_VERSION);
+      req.onupgradeneeded = () => {
+        const db = req.result;
+        if (!db.objectStoreNames.contains('receipts')) {
+          db.createObjectStore('receipts', { keyPath: 'id' }).createIndex('createdAt', 'createdAt');
+        }
+        if (!db.objectStoreNames.contains('splits')) {
+          const store = db.createObjectStore('splits', { keyPath: 'id' });
+          store.createIndex('createdAt', 'createdAt');
+          store.createIndex('imageHash', 'imageHash');
+        }
+        if (!db.objectStoreNames.contains('participants')) {
+          db.createObjectStore('participants', { keyPath: 'id' });
+        }
+        if (!db.objectStoreNames.contains('groups')) {
+          db.createObjectStore('groups', { keyPath: 'id' });
+        }
+        if (!db.objectStoreNames.contains('trips')) {
+          db.createObjectStore('trips', { keyPath: 'id' });
+        }
+        if (!db.objectStoreNames.contains('settings')) {
+          db.createObjectStore('settings', { keyPath: 'key' });
+        }
+        if (!db.objectStoreNames.contains('images')) {
+          db.createObjectStore('images', { keyPath: 'id' });
+        }
+      };
+      req.onsuccess = () => resolve(req.result);
+      req.onerror = () => reject(req.error);
+    });
+    return dbPromise;
+  }
+
+  async function tx(storeName, mode, fn) {
+    const db = await open();
+    return new Promise((resolve, reject) => {
+      const t = db.transaction(storeName, mode);
+      const store = t.objectStore(storeName);
+      const result = fn(store);
+      t.oncomplete = () => resolve(result);
+      t.onerror = () => reject(t.error);
+      t.onabort = () => reject(t.error);
+    });
+  }
+
+  function reqToPromise(req) {
+    return new Promise((resolve, reject) => {
+      req.onsuccess = () => resolve(req.result);
+      req.onerror = () => reject(req.error);
+    });
+  }
+
+  async function put(storeName, value) {
+    const db = await open();
+    return new Promise((resolve, reject) => {
+      const t = db.transaction(storeName, 'readwrite');
+      t.objectStore(storeName).put(value);
+      t.oncomplete = () => resolve(value);
+      t.onerror = () => reject(t.error);
+    });
+  }
+
+  async function get(storeName, key) {
+    const db = await open();
+    const t = db.transaction(storeName, 'readonly');
+    return reqToPromise(t.objectStore(storeName).get(key));
+  }
+
+  async function getAll(storeName) {
+    const db = await open();
+    const t = db.transaction(storeName, 'readonly');
+    const all = await reqToPromise(t.objectStore(storeName).getAll());
+    return all || [];
+  }
+
+  async function del(storeName, key) {
+    const db = await open();
+    return new Promise((resolve, reject) => {
+      const t = db.transaction(storeName, 'readwrite');
+      t.objectStore(storeName).delete(key);
+      t.oncomplete = () => resolve();
+      t.onerror = () => reject(t.error);
+    });
+  }
+
+  async function clearStore(storeName) {
+    const db = await open();
+    return new Promise((resolve, reject) => {
+      const t = db.transaction(storeName, 'readwrite');
+      t.objectStore(storeName).clear();
+      t.oncomplete = () => resolve();
+      t.onerror = () => reject(t.error);
+    });
+  }
+
+  async function deleteAllData() {
+    const stores = ['receipts', 'splits', 'participants', 'groups', 'trips', 'settings', 'images'];
+    for (const s of stores) await clearStore(s);
+  }
+
+  // Simple perceptual-ish hash for duplicate detection: downsizes to 16x16
+  // grayscale, averages, produces a 256-bit signature. Good enough to catch
+  // "same photo imported twice", not a general dedup solution.
+  async function hashImageBlob(blob) {
+    const bitmap = await createImageBitmap(blob);
+    const size = 16;
+    const canvas = document.createElement('canvas');
+    canvas.width = size; canvas.height = size;
+    const ctx = canvas.getContext('2d', { willReadFrequently: true });
+    ctx.drawImage(bitmap, 0, 0, size, size);
+    const { data } = ctx.getImageData(0, 0, size, size);
+    let sum = 0;
+    const gray = [];
+    for (let i = 0; i < data.length; i += 4) {
+      const g = (data[i] * 0.299 + data[i + 1] * 0.587 + data[i + 2] * 0.114);
+      gray.push(g);
+      sum += g;
+    }
+    const avg = sum / gray.length;
+    let hash = '';
+    for (const g of gray) hash += g >= avg ? '1' : '0';
+    // pack bits into hex
+    let hex = '';
+    for (let i = 0; i < hash.length; i += 4) {
+      hex += parseInt(hash.slice(i, i + 4).padEnd(4, '0'), 2).toString(16);
+    }
+    return hex;
+  }
+
+  function hammingDistanceHex(a, b) {
+    if (!a || !b || a.length !== b.length) return Infinity;
+    let dist = 0;
+    for (let i = 0; i < a.length; i++) {
+      let x = parseInt(a[i], 16) ^ parseInt(b[i], 16);
+      while (x) { dist += x & 1; x >>= 1; }
+    }
+    return dist;
+  }
+
+  return { open, put, get, getAll, del, clearStore, deleteAllData, hashImageBlob, hammingDistanceHex };
+})();

--- a/snapsplit/js/debug.js
+++ b/snapsplit/js/debug.js
@@ -1,0 +1,184 @@
+// SnapSplit — developer test panel, activated with ?debug=1.
+// Pure JS assertions against Money / CalcEngine / ReceiptParser. No DOM
+// dependency in the assertions themselves — only in how results are shown.
+'use strict';
+
+function assertEqual(actual, expected, label, results) {
+  const pass = JSON.stringify(actual) === JSON.stringify(expected);
+  results.push({ pass, label, detail: pass ? '' : `expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}` });
+}
+function assertTrue(cond, label, results) {
+  results.push({ pass: !!cond, label, detail: cond ? '' : 'expected truthy' });
+}
+
+function runEngineTests() {
+  const results = [];
+  const mkReceipt = (over) => Object.assign({
+    currency: 'USD', items: [], subtotalCents: 0, discountsCents: 0, taxCents: 0, tipCents: 0, totalCents: 0,
+  }, over);
+
+  // 1. Single-person receipt
+  {
+    const r = mkReceipt({
+      items: [{ id: 'i1', totalPriceCents: 1000, taxable: true, splittable: true, name: 'Item' }],
+      subtotalCents: 1000, totalCents: 1200, taxCents: 200,
+    });
+    const parts = [{ id: 'p1', name: 'Solo', weight: 1 }];
+    const asg = { i1: { mode: 'equal', shares: [{ participantId: 'p1' }] } };
+    const res = CalcEngine.computeSplit(r, parts, asg, {});
+    assertEqual(res.perPerson.p1.totalCents, 1200, 'Single-person receipt totals correctly', results);
+  }
+
+  // 2. Multiple participants, equal split
+  {
+    const r = mkReceipt({ items: [{ id: 'i1', totalPriceCents: 900, taxable: true, splittable: true, name: 'x' }], subtotalCents: 900, totalCents: 900 });
+    const parts = [{ id: 'a', name: 'A', weight: 1 }, { id: 'b', name: 'B', weight: 1 }, { id: 'c', name: 'C', weight: 1 }];
+    const asg = { i1: { mode: 'equal', shares: parts.map(p => ({ participantId: p.id })) } };
+    const res = CalcEngine.computeSplit(r, parts, asg, {});
+    assertEqual([res.perPerson.a.totalCents, res.perPerson.b.totalCents, res.perPerson.c.totalCents], [300, 300, 300], 'Multi-participant equal split divides evenly', results);
+  }
+
+  // 3. Shared item (2 of 3 people)
+  {
+    const r = mkReceipt({ items: [{ id: 'i1', totalPriceCents: 1000, taxable: true, splittable: true, name: 'Nachos' }], subtotalCents: 1000, totalCents: 1000 });
+    const parts = [{ id: 'a', name: 'A', weight: 1 }, { id: 'b', name: 'B', weight: 1 }, { id: 'c', name: 'C', weight: 1 }];
+    const asg = { i1: { mode: 'equal', shares: [{ participantId: 'a' }, { participantId: 'b' }] } };
+    const res = CalcEngine.computeSplit(r, parts, asg, {});
+    assertEqual(res.perPerson.c.totalCents, 0, 'Shared item excludes non-assigned participant', results);
+    assertEqual(res.perPerson.a.totalCents + res.perPerson.b.totalCents, 1000, 'Shared item sums to item total', results);
+  }
+
+  // 4. Weighted split
+  {
+    const r = mkReceipt({ items: [{ id: 'i1', totalPriceCents: 1500, taxable: true, splittable: true, name: 'Family meal' }], subtotalCents: 1500, totalCents: 1500 });
+    const parts = [{ id: 'adult', name: 'Adult', weight: 1 }, { id: 'kid', name: 'Kid', weight: 0.5 }];
+    const asg = { i1: { mode: 'weighted', shares: [{ participantId: 'adult', value: 1 }, { participantId: 'kid', value: 0.5 }] } };
+    const res = CalcEngine.computeSplit(r, parts, asg, {});
+    assertEqual(res.perPerson.adult.totalCents, 1000, 'Weighted split gives adult 2x kid share', results);
+    assertEqual(res.perPerson.kid.totalCents, 500, 'Weighted split gives kid half share', results);
+  }
+
+  // 5. Discounts allocated proportionally
+  {
+    const r = mkReceipt({
+      items: [
+        { id: 'i1', totalPriceCents: 3000, taxable: true, splittable: true, name: 'Steak' },
+        { id: 'i2', totalPriceCents: 1000, taxable: true, splittable: true, name: 'Salad' },
+      ],
+      subtotalCents: 4000, discountsCents: 400, totalCents: 3600,
+    });
+    const parts = [{ id: 'a', name: 'A', weight: 1 }, { id: 'b', name: 'B', weight: 1 }];
+    const asg = { i1: { mode: 'equal', shares: [{ participantId: 'a' }] }, i2: { mode: 'equal', shares: [{ participantId: 'b' }] } };
+    const res = CalcEngine.computeSplit(r, parts, asg, {});
+    assertEqual(res.perPerson.a.discountShareCents, 300, 'Discount allocated 3:1 proportional to item share (A)', results);
+    assertEqual(res.perPerson.b.discountShareCents, 100, 'Discount allocated 3:1 proportional to item share (B)', results);
+  }
+
+  // 6. Tax and tip proportional allocation
+  {
+    const r = mkReceipt({
+      items: [
+        { id: 'i1', totalPriceCents: 3000, taxable: true, splittable: true, name: 'Steak' },
+        { id: 'i2', totalPriceCents: 1000, taxable: true, splittable: true, name: 'Salad' },
+      ],
+      subtotalCents: 4000, taxCents: 320, tipCents: 800, totalCents: 5120,
+    });
+    const parts = [{ id: 'a', name: 'A', weight: 1 }, { id: 'b', name: 'B', weight: 1 }];
+    const asg = { i1: { mode: 'equal', shares: [{ participantId: 'a' }] }, i2: { mode: 'equal', shares: [{ participantId: 'b' }] } };
+    const res = CalcEngine.computeSplit(r, parts, asg, {});
+    assertTrue(res.reconciles, 'Tax + tip allocation reconciles to exact receipt total', results);
+    assertEqual(res.perPerson.a.taxShareCents + res.perPerson.b.taxShareCents, 320, 'Tax shares sum to total tax', results);
+  }
+
+  // 7. One-cent remainder (largest-remainder rounding)
+  {
+    const r = mkReceipt({ items: [{ id: 'i1', totalPriceCents: 1000, taxable: true, splittable: true, name: 'Split 3 ways' }], subtotalCents: 1000, totalCents: 1000 });
+    const parts = [{ id: 'a', name: 'A' }, { id: 'b', name: 'B' }, { id: 'c', name: 'C' }];
+    const asg = { i1: { mode: 'equal', shares: parts.map(p => ({ participantId: p.id })) } };
+    const res = CalcEngine.computeSplit(r, parts, asg, {});
+    const total = res.perPerson.a.totalCents + res.perPerson.b.totalCents + res.perPerson.c.totalCents;
+    assertEqual(total, 1000, '1000 cents / 3 people sums to exactly 1000 (no lost penny)', results);
+    assertTrue(res.perPerson.a.totalCents === 334 || res.perPerson.a.totalCents === 333, 'Remainder cent assigned deterministically', results);
+  }
+
+  // 8. Zero-value item
+  {
+    const r = mkReceipt({ items: [{ id: 'i1', totalPriceCents: 0, taxable: true, splittable: true, name: 'Free appetizer' }], subtotalCents: 0, totalCents: 0 });
+    const parts = [{ id: 'a', name: 'A' }, { id: 'b', name: 'B' }];
+    const asg = { i1: { mode: 'equal', shares: parts.map(p => ({ participantId: p.id })) } };
+    const res = CalcEngine.computeSplit(r, parts, asg, {});
+    assertEqual([res.perPerson.a.totalCents, res.perPerson.b.totalCents], [0, 0], 'Zero-value item splits to zero without error', results);
+  }
+
+  // 9. Negative discount (comp / promo) larger than typical
+  {
+    const r = mkReceipt({
+      items: [{ id: 'i1', totalPriceCents: 2000, taxable: true, splittable: true, name: 'Entree' }],
+      subtotalCents: 2000, discountsCents: 2000, totalCents: 0,
+    });
+    const parts = [{ id: 'a', name: 'A' }];
+    const asg = { i1: { mode: 'equal', shares: [{ participantId: 'a' }] } };
+    const res = CalcEngine.computeSplit(r, parts, asg, {});
+    assertEqual(res.perPerson.a.totalCents, 0, 'Full discount zeroes out the total', results);
+  }
+
+  // 10. Unbalanced receipt is flagged, never silently accepted
+  {
+    const rec = CalcEngine.reconcileReceipt(mkReceipt({
+      items: [{ id: 'i1', totalPriceCents: 1000, splittable: true, name: 'x' }],
+      subtotalCents: 1000, taxCents: 100, totalCents: 5000,
+    }));
+    assertTrue(rec.balanced === false, 'Unbalanced receipt (total does not match subtotal+tax) is flagged', results);
+  }
+
+  // 11. Duplicate receipt detection (hamming distance helper)
+  {
+    const d = SnapDB.hammingDistanceHex('ff00', 'ff00');
+    assertEqual(d, 0, 'Identical image hashes have zero hamming distance', results);
+    const d2 = SnapDB.hammingDistanceHex('ff00', '0000');
+    assertTrue(d2 > 0, 'Different image hashes have nonzero hamming distance', results);
+  }
+
+  // 12. Trip Ledger settlement / debt simplification
+  {
+    const balances = [{ id: 'alice', name: 'Alice', net: 5000 }, { id: 'bob', name: 'Bob', net: -2000 }, { id: 'carla', name: 'Carla', net: -3000 }];
+    const txns = CalcEngine.simplifyDebts(balances);
+    assertEqual(txns.length, 2, 'Debt simplification uses minimum transactions for classic 3-person example', results);
+    const sumToAlice = txns.filter(t => t.to === 'alice').reduce((a, t) => a + t.amountCents, 0);
+    assertEqual(sumToAlice, 5000, 'All money owed to Alice is accounted for', results);
+  }
+
+  // 13. Parser round trip on bundled fixtures (balanced ones only)
+  {
+    const sampleText = `TEST DINER\n01/01/2026\n1 x Burger  10.00\nSubtotal  10.00\nTax  1.00\nTotal  11.00\n`;
+    const parsed = ReceiptParser.parseReceiptText(sampleText);
+    assertEqual(parsed.items.length, 1, 'Parser extracts exactly one item from simple fixture', results);
+    assertEqual(parsed.totalCents, 1100, 'Parser reads total correctly', results);
+  }
+
+  // 14. Money allocation never loses or gains a cent, incl. large weight sets
+  {
+    const weights = Array.from({ length: 7 }, (_, i) => i + 1);
+    const allocated = Money.allocateProportional(9999, weights);
+    assertEqual(Money.sum(allocated), 9999, 'Proportional allocation across 7 weighted shares sums exactly', results);
+  }
+
+  return results;
+}
+
+function renderDebugPanel() {
+  const panel = $('#debugPanel');
+  panel.innerHTML = '';
+  panel.appendChild(el('div', { style: 'max-width:720px;margin:0 auto' }, [
+    el('h2', {}, '🧪 SnapSplit developer test panel'),
+    el('p', { class: 'muted small' }, 'Pure JS assertions against the calculation engine and parser. Visible via ?debug=1.'),
+  ]));
+  const results = runEngineTests();
+  const summary = el('p', {}, `${results.filter(r => r.pass).length} / ${results.length} passed`);
+  panel.appendChild(summary);
+  results.forEach(r => {
+    panel.appendChild(el('div', { class: 'test-result ' + (r.pass ? 'pass' : 'fail') },
+      `${r.pass ? '✓' : '✗'} ${r.label}${r.detail ? ' — ' + r.detail : ''}`));
+  });
+  panel.appendChild(el('button', { class: 'btn block', style: 'margin-top:16px', onclick: () => { panel.style.display = 'none'; } }, 'Close test panel'));
+}

--- a/snapsplit/js/entitlements.js
+++ b/snapsplit/js/entitlements.js
@@ -1,0 +1,65 @@
+// SnapSplit — centralized entitlement gate. Every premium check in the app
+// goes through this module so swapping in a real license provider later
+// (Lemon Squeezy, Paddle, Stripe, ...) means editing ONE function.
+'use strict';
+
+const Entitlements = (() => {
+  const FREE_LIMITS = {
+    maxReceiptsPerSplit: 1,
+    maxParticipants: 8,
+    maxSavedSplits: 5,
+  };
+
+  const PREMIUM_FEATURES = [
+    'unlimitedSavedSplits',
+    'unlimitedParticipants',
+    'batchReceiptImport',
+    'longReceiptStitching',
+    'customAllocationRules',
+    'recurringGroups',
+    'csvExport',
+    'polishedPrintReport',
+    'encryptedBackup',
+    'removeBranding',
+    'tripLedger',
+    'debtSimplification',
+  ];
+
+  let cached = { valid: false, plan: 'free', checkedAt: 0 };
+
+  // AIDEV: connect to Lemon Squeezy, Paddle, or another license provider.
+  // Replace the body of this function only — nothing else in the app should
+  // ever need to change to swap providers. Must not throw; return a safe
+  // { valid:false, plan:'free' } on any network/parsing failure.
+  async function validateLicense(key) {
+    return {
+      valid: false,
+      plan: 'free',
+    };
+  }
+
+  async function getPlan() {
+    const saved = await SnapDB.get('settings', 'license').catch(() => null);
+    if (!saved || !saved.licenseKey) return { valid: false, plan: 'free' };
+    if (Date.now() - cached.checkedAt < 5 * 60 * 1000 && cached.key === saved.licenseKey) return cached;
+    const result = await validateLicense(saved.licenseKey);
+    cached = { ...result, checkedAt: Date.now(), key: saved.licenseKey };
+    return result;
+  }
+
+  async function isPremium() {
+    const plan = await getPlan();
+    return !!plan.valid && plan.plan !== 'free';
+  }
+
+  async function has(feature) {
+    if (!PREMIUM_FEATURES.includes(feature)) return true; // not a gated feature
+    return await isPremium();
+  }
+
+  function limits() {
+    return { ...FREE_LIMITS };
+  }
+
+  return { validateLicense, getPlan, isPremium, has, limits, PREMIUM_FEATURES };
+})();

--- a/snapsplit/js/history.js
+++ b/snapsplit/js/history.js
@@ -1,0 +1,56 @@
+// SnapSplit — History browser (topbar).
+'use strict';
+
+$('#btnHistory').addEventListener('click', openHistoryDialog);
+
+async function openHistoryDialog() {
+  const wrap = el('div', { style: 'min-width:min(80vw,420px)' });
+  wrap.appendChild(el('h3', {}, 'History'));
+  const search = el('input', { type: 'search', placeholder: 'Search merchant or date…', 'aria-label': 'Search history' });
+  wrap.appendChild(search);
+  const list = el('div', { style: 'margin-top:10px; max-height:50vh; overflow:auto' });
+  wrap.appendChild(list);
+
+  const all = await SnapDB.getAll('splits');
+  const limits = Entitlements.limits();
+  const isPremium = await Entitlements.has('unlimitedSavedSplits');
+
+  function draw(filter) {
+    list.innerHTML = '';
+    const sorted = all.sort((a, b) => b.createdAt - a.createdAt);
+    const filtered = filter ? sorted.filter(s => (s.merchant || '').toLowerCase().includes(filter.toLowerCase()) || (s.date || '').includes(filter)) : sorted;
+    if (!filtered.length) { list.appendChild(el('p', { class: 'muted small' }, 'No saved splits yet.')); return; }
+    filtered.forEach((s, i) => {
+      const locked = !isPremium && i >= limits.maxSavedSplits;
+      const row = el('div', { class: 'history-item' });
+      row.appendChild(el('div', {}, [
+        el('strong', {}, s.merchant || 'Unnamed'), locked ? el('span', { class: 'badge-lock' }, 'LOCKED') : '',
+        el('div', { class: 'muted small' }, [s.date, new Date(s.createdAt).toLocaleString()].filter(Boolean).join(' · ')),
+      ]));
+      const actions = el('div', { class: 'row', style: 'flex:0 0 auto; gap:6px' });
+      const openBtn = el('button', { class: 'btn sm', disabled: locked }, 'Open');
+      openBtn.addEventListener('click', () => { loadSplitRecord(s); closeDialog(); setStep('settle'); });
+      const delBtn = el('button', { class: 'btn sm danger' }, 'Delete');
+      delBtn.addEventListener('click', async () => { await SnapDB.del('splits', s.id); row.remove(); });
+      actions.append(openBtn, delBtn);
+      row.appendChild(actions);
+      list.appendChild(row);
+    });
+  }
+  draw('');
+  search.addEventListener('input', () => draw(search.value));
+
+  const footer = el('div', { class: 'row', style: 'margin-top:12px' });
+  footer.appendChild(el('button', { class: 'btn ghost', onclick: closeDialog }, 'Close'));
+  footer.appendChild(el('button', {
+    class: 'btn danger', onclick: async () => {
+      if (!confirm('Delete ALL local SnapSplit data? This cannot be undone.')) return;
+      await SnapDB.deleteAllData();
+      toast('All local data deleted.', 'success');
+      closeDialog();
+    }
+  }, 'Delete all local data'));
+  wrap.appendChild(footer);
+
+  openDialog(wrap);
+}

--- a/snapsplit/js/image-processing.js
+++ b/snapsplit/js/image-processing.js
@@ -1,0 +1,109 @@
+// SnapSplit — canvas-based image preprocessing before OCR: orientation fix,
+// downscale, grayscale, contrast stretch, optional threshold. Runs on the
+// main thread (Canvas2D isn't available in a worker without OffscreenCanvas
+// support everywhere we target); OCR itself — the expensive part — runs in
+// Tesseract.js's own Web Worker.
+'use strict';
+
+const ImageProcessing = (() => {
+  const MAX_DIM = 2000;
+
+  async function loadBitmapWithOrientation(file) {
+    // createImageBitmap with imageOrientation:'from-image' respects EXIF
+    // rotation on browsers that support it; falls back gracefully otherwise.
+    try {
+      return await createImageBitmap(file, { imageOrientation: 'from-image' });
+    } catch (e) {
+      return await createImageBitmap(file);
+    }
+  }
+
+  function bitmapToCanvas(bitmap, maxDim) {
+    let { width, height } = bitmap;
+    const scale = Math.min(1, (maxDim || MAX_DIM) / Math.max(width, height));
+    const w = Math.round(width * scale);
+    const h = Math.round(height * scale);
+    const canvas = document.createElement('canvas');
+    canvas.width = w; canvas.height = h;
+    const ctx = canvas.getContext('2d', { willReadFrequently: true });
+    ctx.drawImage(bitmap, 0, 0, w, h);
+    return canvas;
+  }
+
+  function rotateCanvas(canvas, degrees) {
+    const rad = (degrees * Math.PI) / 180;
+    const swap = Math.abs(degrees % 180) === 90;
+    const out = document.createElement('canvas');
+    out.width = swap ? canvas.height : canvas.width;
+    out.height = swap ? canvas.width : canvas.height;
+    const ctx = out.getContext('2d');
+    ctx.translate(out.width / 2, out.height / 2);
+    ctx.rotate(rad);
+    ctx.drawImage(canvas, -canvas.width / 2, -canvas.height / 2);
+    return out;
+  }
+
+  function cropCanvas(canvas, rectNorm) {
+    // rectNorm: {x,y,w,h} in 0..1 fractions of canvas size
+    const sx = Math.round(rectNorm.x * canvas.width);
+    const sy = Math.round(rectNorm.y * canvas.height);
+    const sw = Math.round(rectNorm.w * canvas.width);
+    const sh = Math.round(rectNorm.h * canvas.height);
+    const out = document.createElement('canvas');
+    out.width = sw; out.height = sh;
+    out.getContext('2d').drawImage(canvas, sx, sy, sw, sh, 0, 0, sw, sh);
+    return out;
+  }
+
+  function toGrayscaleContrastThreshold(canvas, opts) {
+    opts = opts || {};
+    const grayscale = opts.grayscale !== false;
+    const contrast = opts.contrast ?? 1.25; // >1 boosts contrast
+    const threshold = opts.threshold; // 0-255, or null/undefined to skip
+    const ctx = canvas.getContext('2d', { willReadFrequently: true });
+    const imgData = ctx.getImageData(0, 0, canvas.width, canvas.height);
+    const d = imgData.data;
+
+    // pass 1: grayscale + contrast, tracking min/max for auto-stretch
+    let min = 255, max = 0;
+    const grayVals = new Float32Array(d.length / 4);
+    for (let i = 0, j = 0; i < d.length; i += 4, j++) {
+      let g = grayscale ? (d[i] * 0.299 + d[i + 1] * 0.587 + d[i + 2] * 0.114) : (d[i] + d[i + 1] + d[i + 2]) / 3;
+      grayVals[j] = g;
+      if (g < min) min = g;
+      if (g > max) max = g;
+    }
+    const range = Math.max(1, max - min);
+    for (let i = 0, j = 0; i < d.length; i += 4, j++) {
+      let g = ((grayVals[j] - min) / range) * 255;
+      g = 128 + (g - 128) * contrast;
+      g = Math.max(0, Math.min(255, g));
+      if (threshold != null) g = g >= threshold ? 255 : 0;
+      d[i] = d[i + 1] = d[i + 2] = g;
+    }
+    ctx.putImageData(imgData, 0, 0);
+    return canvas;
+  }
+
+  async function preprocess(file, opts) {
+    opts = opts || {};
+    const bitmap = await loadBitmapWithOrientation(file);
+    let canvas = bitmapToCanvas(bitmap, opts.maxDim);
+    if (opts.rotateDegrees) canvas = rotateCanvas(canvas, opts.rotateDegrees);
+    if (opts.cropRect) canvas = cropCanvas(canvas, opts.cropRect);
+    if (opts.enhance !== false) {
+      canvas = toGrayscaleContrastThreshold(canvas, {
+        grayscale: opts.grayscale,
+        contrast: opts.contrast,
+        threshold: opts.threshold,
+      });
+    }
+    return canvas;
+  }
+
+  function canvasToBlob(canvas, type, quality) {
+    return new Promise(resolve => canvas.toBlob(resolve, type || 'image/png', quality));
+  }
+
+  return { loadBitmapWithOrientation, bitmapToCanvas, rotateCanvas, cropCanvas, toGrayscaleContrastThreshold, preprocess, canvasToBlob };
+})();

--- a/snapsplit/js/ledger.js
+++ b/snapsplit/js/ledger.js
@@ -1,0 +1,130 @@
+// SnapSplit — Trip Ledger: combine multiple saved splits, net balances, debt simplification.
+'use strict';
+
+$('#btnLedger').addEventListener('click', openLedgerDialog);
+
+async function openLedgerDialog() {
+  const premium = await Entitlements.has('tripLedger');
+  const trips = await SnapDB.getAll('trips');
+  const wrap = el('div', { style: 'min-width:min(85vw,460px)' });
+  wrap.appendChild(el('h3', {}, '🧮 Trip Ledger'));
+  if (!premium) {
+    wrap.appendChild(el('div', { class: 'discrepancy-banner bad' }, 'Trip Ledger is a premium feature. You can preview it below with a demo trip; enter a license key in Settings to unlock real trips.'));
+  }
+  wrap.appendChild(el('p', { class: 'small muted' }, 'Combine several completed splits into one trip and settle everyone at once with as few payments as possible.'));
+
+  const list = el('div');
+  trips.forEach(t => list.appendChild(renderTripRow(t)));
+  wrap.appendChild(list);
+
+  const newBtn = el('button', { class: 'btn primary block', style: 'margin-top:10px' }, '+ New trip');
+  newBtn.addEventListener('click', () => openTripEditor(null));
+  wrap.appendChild(newBtn);
+
+  const demoBtn = el('button', { class: 'btn ghost block', style: 'margin-top:6px' }, 'Load debt-simplification demo');
+  demoBtn.addEventListener('click', () => {
+    const balances = [{ id: 'a', name: 'Alice', net: 5000 }, { id: 'b', name: 'Bob', net: -2000 }, { id: 'c', name: 'Carla', net: -3000 }];
+    const txns = CalcEngine.simplifyDebts(balances);
+    showTripSettlement({ name: 'Demo trip', currency: 'USD' }, balances, txns);
+  });
+  wrap.appendChild(demoBtn);
+
+  wrap.appendChild(el('button', { class: 'btn ghost block', style: 'margin-top:6px', onclick: closeDialog }, 'Close'));
+  openDialog(wrap);
+}
+
+function renderTripRow(trip) {
+  const row = el('div', { class: 'history-item' });
+  row.appendChild(el('div', {}, [el('strong', {}, trip.name), el('div', { class: 'muted small' }, `${(trip.splitIds || []).length} receipts · ${trip.currency}`)]));
+  const openBtn = el('button', { class: 'btn sm' }, 'Open');
+  openBtn.addEventListener('click', () => openTripEditor(trip));
+  row.appendChild(openBtn);
+  return row;
+}
+
+async function openTripEditor(trip) {
+  const isNew = !trip;
+  trip = trip || { id: uid('trip'), name: 'New Trip', currency: 'USD', splitIds: [], payers: {} };
+  const allSplits = await SnapDB.getAll('splits');
+
+  const wrap = el('div', { style: 'min-width:min(85vw,460px)' });
+  wrap.appendChild(el('h3', {}, isNew ? 'New trip' : trip.name));
+  const nameInput = el('input', { type: 'text', value: trip.name });
+  nameInput.addEventListener('change', () => trip.name = nameInput.value);
+  wrap.appendChild(labeledField('Trip name', nameInput));
+
+  wrap.appendChild(el('h3', { style: 'margin-top:12px' }, 'Include receipts'));
+  const list = el('div', { style: 'max-height:35vh; overflow:auto' });
+  allSplits.forEach(s => {
+    const checked = trip.splitIds.includes(s.id);
+    const row = el('label', { style: 'display:flex; align-items:center; gap:8px; padding:6px 0; border-bottom:1px solid var(--border)' });
+    const cb = el('input', { type: 'checkbox', checked });
+    cb.addEventListener('change', () => {
+      if (cb.checked) trip.splitIds.push(s.id); else trip.splitIds = trip.splitIds.filter(id => id !== s.id);
+    });
+    row.append(cb, el('span', {}, `${s.merchant || 'Unnamed'} — ${Money.format(s.receipt.totalCents, s.receipt.currency)}`));
+    list.appendChild(row);
+  });
+  wrap.appendChild(list);
+
+  const row = el('div', { class: 'row', style: 'margin-top:12px' });
+  row.appendChild(el('button', { class: 'btn ghost', onclick: closeDialog }, 'Cancel'));
+  row.appendChild(el('button', {
+    class: 'btn primary', onclick: async () => {
+      await SnapDB.put('trips', trip);
+      closeDialog();
+      computeAndShowTrip(trip, allSplits);
+    }
+  }, 'Save & settle'));
+  wrap.appendChild(row);
+  openDialog(wrap);
+}
+
+function labeledField(label, inputEl) {
+  const f = el('div', { class: 'field' });
+  f.appendChild(el('label', {}, label));
+  f.appendChild(inputEl);
+  return f;
+}
+
+function computeAndShowTrip(trip, allSplits) {
+  const included = allSplits.filter(s => trip.splitIds.includes(s.id));
+  if (!included.length) { toast('Add at least one receipt to the trip.', 'error'); return; }
+  const balanceMap = new Map();
+  included.forEach(s => {
+    const result = CalcEngine.computeSplit(s.receipt, s.participants, s.assignments, { taxMode: s.taxMode, tipMode: s.tipMode });
+    const numPayers = s.participants.filter(p => p.isPayer).length || 1;
+    s.participants.forEach(p => {
+      const key = p.name.trim().toLowerCase();
+      const pr = result.perPerson[p.id];
+      const paid = p.isPayer ? Math.round(result.grandTotal / numPayers) : 0;
+      const net = paid - pr.totalCents;
+      balanceMap.set(key, (balanceMap.get(key) || { id: key, name: p.name, net: 0 }));
+      balanceMap.get(key).net += net;
+    });
+  });
+  const balances = [...balanceMap.values()];
+  const txns = CalcEngine.simplifyDebts(balances);
+  showTripSettlement(trip, balances, txns);
+}
+
+function showTripSettlement(trip, balances, txns) {
+  const wrap = el('div', { style: 'min-width:min(85vw,460px)' });
+  wrap.appendChild(el('h3', {}, `${trip.name} — settlement`));
+  wrap.appendChild(el('p', { class: 'small muted' }, 'Debt simplification is a greedy heuristic (minimizes transactions in common cases, not proven globally optimal).'));
+  balances.forEach(b => {
+    wrap.appendChild(el('div', { class: 'totals-grid' }, [
+      el('div', { class: 'label' }, b.name),
+      el('div', { class: 'val' }, (b.net >= 0 ? '+' : '') + Money.format(b.net, trip.currency || 'USD')),
+    ]));
+  });
+  wrap.appendChild(el('h3', { style: 'margin-top:12px' }, 'Pay up'));
+  if (!txns.length) wrap.appendChild(el('p', { class: 'muted' }, 'Everyone is already square.'));
+  txns.forEach(t => {
+    wrap.appendChild(el('div', { class: 'result-card', style: 'display:flex; justify-content:space-between' }, [
+      el('span', {}, `${t.fromName} → ${t.toName}`), el('strong', {}, Money.format(t.amountCents, trip.currency || 'USD')),
+    ]));
+  });
+  wrap.appendChild(el('button', { class: 'btn block', style: 'margin-top:10px', onclick: closeDialog }, 'Close'));
+  openDialog(wrap);
+}

--- a/snapsplit/js/money.js
+++ b/snapsplit/js/money.js
@@ -1,0 +1,85 @@
+// SnapSplit — money & allocation primitives. All amounts are integer minor units (cents).
+// Never do currency arithmetic in floating point beyond this file's controlled rounding points.
+'use strict';
+
+const Money = (() => {
+
+  function toCents(amount) {
+    if (amount === '' || amount === null || amount === undefined) return 0;
+    const n = typeof amount === 'string' ? parseFloat(amount.replace(',', '.')) : amount;
+    if (!isFinite(n)) return 0;
+    return Math.round(n * 100);
+  }
+
+  function fromCents(cents) {
+    return cents / 100;
+  }
+
+  function format(cents, currency) {
+    const sign = cents < 0 ? '-' : '';
+    const abs = Math.abs(cents);
+    const whole = Math.floor(abs / 100);
+    const frac = String(abs % 100).padStart(2, '0');
+    const symbol = currencySymbol(currency);
+    return `${sign}${symbol}${whole.toLocaleString('en-US')}.${frac}`;
+  }
+
+  function currencySymbol(code) {
+    switch ((code || 'USD').toUpperCase()) {
+      case 'USD': return '$';
+      case 'EUR': return '€';
+      case 'GBP': return '£';
+      case 'JPY': return '¥';
+      case 'CAD': return 'CA$';
+      case 'AUD': return 'A$';
+      default: return (code || '') + ' ';
+    }
+  }
+
+  // Distributes `totalCents` across `weights` proportionally, using the
+  // largest-remainder method so the parts always sum EXACTLY to totalCents.
+  // Works for totalCents of either sign; weights must be >= 0.
+  function allocateProportional(totalCents, weights) {
+    const n = weights.length;
+    if (n === 0) return [];
+    const sumWeights = weights.reduce((a, b) => a + b, 0);
+    if (sumWeights <= 0) {
+      return allocateProportional(totalCents, weights.map(() => 1));
+    }
+    const sign = totalCents < 0 ? -1 : 1;
+    const absTotal = Math.abs(totalCents);
+
+    const raw = weights.map(w => (absTotal * w) / sumWeights);
+    const floors = raw.map(Math.floor);
+    const allocated = floors.reduce((a, b) => a + b, 0);
+    let remainder = Math.round(absTotal - allocated);
+
+    const order = raw
+      .map((r, i) => ({ i, frac: r - floors[i] }))
+      .sort((a, b) => b.frac - a.frac || a.i - b.i);
+
+    const result = floors.slice();
+    for (let k = 0; k < remainder; k++) {
+      result[order[k % n].i] += 1;
+    }
+    return result.map(c => c * sign);
+  }
+
+  // Splits totalCents equally among n shares, largest-remainder deterministic
+  // (earlier indices get the extra cent first).
+  function allocateEqual(totalCents, n) {
+    return allocateProportional(totalCents, new Array(n).fill(1));
+  }
+
+  function sum(arr) {
+    return arr.reduce((a, b) => a + b, 0);
+  }
+
+  function round2(n) {
+    return Math.round(n * 100) / 100;
+  }
+
+  return { toCents, fromCents, format, currencySymbol, allocateProportional, allocateEqual, sum, round2 };
+})();
+
+if (typeof module !== 'undefined') module.exports = Money;

--- a/snapsplit/js/ocr.js
+++ b/snapsplit/js/ocr.js
@@ -1,0 +1,30 @@
+// SnapSplit — Tesseract.js wrapper. Tesseract.js manages its own Web Worker
+// internally, so the actual OCR recognition (the expensive part) never runs
+// on the main thread even though this call site looks synchronous.
+'use strict';
+
+let tesseractWorkerPromise = null;
+
+async function getTesseractWorker(onProgress) {
+  if (tesseractWorkerPromise) return tesseractWorkerPromise;
+  tesseractWorkerPromise = Tesseract.createWorker('eng', 1, {
+    logger: m => {
+      if (!onProgress) return;
+      const label = {
+        'loading tesseract core': 'Loading OCR engine…',
+        'initializing tesseract': 'Initializing OCR engine…',
+        'loading language traineddata': 'Downloading language model…',
+        'initializing api': 'Preparing recognizer…',
+        'recognizing text': 'Reading text…',
+      }[m.status] || m.status;
+      onProgress(label, m.progress || 0);
+    },
+  });
+  return tesseractWorkerPromise;
+}
+
+async function runTesseractOcr(blob, onProgress) {
+  const worker = await getTesseractWorker(onProgress);
+  const { data } = await worker.recognize(blob);
+  return data.text;
+}

--- a/snapsplit/js/parser.js
+++ b/snapsplit/js/parser.js
@@ -1,0 +1,210 @@
+// SnapSplit — receipt text parser. Turns raw OCR (or pasted) text into a
+// structured receipt object. Heuristic by nature: always paired with the
+// reconciliation check in calc.js and a manual-edit UI, never trusted blindly.
+'use strict';
+
+const ReceiptParser = (() => {
+
+  const MONEY_RE = /-?\$?\s?\d{1,3}(?:[.,]\d{3})*[.,]\d{2}\b|-?\$?\s?\d+[.,]\d{2}\b/;
+  const MONEY_RE_G = new RegExp(MONEY_RE.source, 'g');
+  const QTY_PREFIX_RE = /^\s*(\d+)\s*[xX*]\s*(.+)$/;             // "2 x Latte"
+  const QTY_AT_RE = /^(.*?)\s+(\d+)\s*[xX@]\s*\$?(\d+[.,]\d{2})\s*$/; // "Latte 2 x 4.50"
+  const LEADING_QTY_RE = /^\s*(\d+)\s+(?=[A-Za-z])/;             // "2 Garlic Bread"
+
+  const SUBTOTAL_WORDS = /^(sub\s?total|subtotal|item(s)?\s*total|net\s*amount)\b/i;
+  const TAX_WORDS = /\b(tax|vat|gst|hst|sales\s*tax)\b/i;
+  const TIP_WORDS = /\b(tip|gratuity|service\s*charge)\b/i;
+  const DISCOUNT_WORDS = /\b(discount|coupon|promo|comp\b|savings)\b/i;
+  const TOTAL_WORDS = /^(grand\s*total|total\s*due|balance\s*due|amount\s*due|total)\b/i;
+  const NOISE_WORDS = /\b(visa|mastercard|amex|discover|card|auth|approval|terminal|order\s*#|order\s*number|table|server|phone|tel|invoice|receipt\s*#|ref\s*#|id\s*:|cashier|change\s*due|cash\s*tendered)\b/i;
+  const PHONE_RE = /\(?\d{3}\)?[\s.-]\d{3}[\s.-]\d{4}/;
+  const CARD_MASK_RE = /\*{2,}\d{2,6}/;
+  const DATE_RE = /\b(\d{4}-\d{2}-\d{2}|\d{1,2}\/\d{1,2}\/\d{2,4}|\d{1,2}-\d{1,2}-\d{4})\b/;
+
+  function parseMoneyToken(tok) {
+    if (!tok) return null;
+    let neg = /^-/.test(tok.trim()) || /^\(.*\)$/.test(tok.trim());
+    let cleaned = tok.replace(/[()$\s]/g, '').replace(/^-/, '');
+    // normalize thousands/decimal: assume last separator (. or ,) before 2 digits is decimal
+    const m = cleaned.match(/^(\d[\d.,]*\d)$/);
+    if (!m) return null;
+    let s = m[1];
+    const lastDot = s.lastIndexOf('.');
+    const lastComma = s.lastIndexOf(',');
+    const decIdx = Math.max(lastDot, lastComma);
+    if (decIdx === -1) return null;
+    const intPart = s.slice(0, decIdx).replace(/[.,]/g, '');
+    const fracPart = s.slice(decIdx + 1);
+    if (fracPart.length !== 2) return null;
+    const cents = parseInt(intPart || '0', 10) * 100 + parseInt(fracPart, 10) * (neg ? -1 : 1);
+    return neg ? -Math.abs(parseInt(intPart || '0', 10) * 100 + parseInt(fracPart, 10)) : cents;
+  }
+
+  function looksLikeNoise(line) {
+    if (NOISE_WORDS.test(line)) return true;
+    if (PHONE_RE.test(line)) return true;
+    if (CARD_MASK_RE.test(line)) return true;
+    if (/^\d{4,}$/.test(line.trim())) return true; // bare long numeric IDs
+    if (/\b\d{1,2}:\d{2}\s*(am|pm)?\b/i.test(line)) return true; // timestamps
+    return false;
+  }
+
+  function extractAllMoney(line) {
+    const matches = line.match(MONEY_RE_G) || [];
+    return matches.map(parseMoneyToken).filter(v => v !== null);
+  }
+
+  function lastMoneyOnLine(line) {
+    const all = extractAllMoney(line);
+    return all.length ? all[all.length - 1] : null;
+  }
+
+  function parseReceiptText(rawText) {
+    const lines = rawText
+      .split(/\r?\n/)
+      .map(l => l.replace(/\s+/g, ' ').trim())
+      .filter(l => l.length > 0);
+
+    const result = {
+      merchant: '',
+      date: '',
+      currency: 'USD',
+      items: [],
+      subtotalCents: null,
+      discountsCents: 0,
+      taxCents: 0,
+      tipCents: 0,
+      totalCents: null,
+      lowConfidenceFields: [],
+    };
+
+    if (lines.length) result.merchant = lines[0].slice(0, 60);
+    for (const l of lines.slice(0, 6)) {
+      const dm = l.match(DATE_RE);
+      if (dm) { result.date = dm[0]; break; }
+    }
+
+    let pendingName = null;
+
+    const HEADER_NOISE_RE = /^(date|time|order\s*date)\s*:/i;
+    const ADDRESS_RE = /\d+\s+\w+.*\b(st|street|ave|avenue|rd|road|blvd|drive|dr|way|ln|lane)\b\.?,?/i;
+
+    for (let idx = 0; idx < lines.length; idx++) {
+      const line = lines[idx];
+
+      if (idx === 0) continue; // already captured as merchant name
+      if (HEADER_NOISE_RE.test(line) || ADDRESS_RE.test(line) || DATE_RE.test(line)) continue;
+
+      if (SUBTOTAL_WORDS.test(line)) {
+        const v = lastMoneyOnLine(line);
+        if (v !== null) result.subtotalCents = v;
+        pendingName = null;
+        continue;
+      }
+      if (TOTAL_WORDS.test(line) && !SUBTOTAL_WORDS.test(line)) {
+        const v = lastMoneyOnLine(line);
+        if (v !== null) result.totalCents = v;
+        pendingName = null;
+        continue;
+      }
+      if (TAX_WORDS.test(line)) {
+        const v = lastMoneyOnLine(line);
+        if (v !== null) result.taxCents += v;
+        pendingName = null;
+        continue;
+      }
+      if (TIP_WORDS.test(line)) {
+        const v = lastMoneyOnLine(line);
+        if (v !== null) result.tipCents += v;
+        pendingName = null;
+        continue;
+      }
+      if (DISCOUNT_WORDS.test(line)) {
+        const v = lastMoneyOnLine(line);
+        if (v !== null) result.discountsCents += Math.abs(v);
+        pendingName = null;
+        continue;
+      }
+      if (looksLikeNoise(line)) { continue; }
+
+      const money = extractAllMoney(line);
+      if (money.length === 0) {
+        // Could be a wrapped item name continuation, or plain header noise.
+        if (line.length < 40 && !/^\d+$/.test(line)) {
+          pendingName = pendingName ? pendingName + ' ' + line : line.replace(LEADING_QTY_RE, '').trim();
+        }
+        continue;
+      }
+
+      // Line has at least one money value -> treat as an item line.
+      let name = line;
+      let quantity = 1;
+      let unitPriceCents, totalPriceCents;
+
+      const qtyAt = line.match(QTY_AT_RE);
+      const qtyPrefix = line.match(QTY_PREFIX_RE);
+
+      if (money.length >= 2 && qtyAt) {
+        quantity = parseInt(qtyAt[2], 10);
+        unitPriceCents = parseMoneyToken(qtyAt[3]);
+        totalPriceCents = money[money.length - 1];
+        name = qtyAt[1];
+      } else if (qtyPrefix) {
+        quantity = parseInt(qtyPrefix[1], 10);
+        name = qtyPrefix[2].replace(MONEY_RE_G, '').trim();
+        totalPriceCents = money[money.length - 1];
+        unitPriceCents = quantity > 0 ? Math.round(totalPriceCents / quantity) : totalPriceCents;
+      } else {
+        const leadQty = line.match(LEADING_QTY_RE);
+        if (leadQty) quantity = parseInt(leadQty[1], 10) || 1;
+        name = line.replace(MONEY_RE_G, '').replace(LEADING_QTY_RE, '').trim();
+        totalPriceCents = money[money.length - 1];
+        unitPriceCents = quantity > 0 ? Math.round(totalPriceCents / quantity) : totalPriceCents;
+      }
+
+      name = name.replace(/@\s*$/, '').replace(/[-–—.\s]{2,}$/, '').trim();
+      if (pendingName) { name = `${pendingName} ${name}`.trim(); }
+      if (!name) name = `Item ${result.items.length + 1}`;
+
+      const confidence = estimateConfidence(line, name, totalPriceCents);
+      const item = {
+        id: 'it_' + Math.random().toString(36).slice(2, 10),
+        name,
+        quantity: quantity || 1,
+        unitPriceCents: unitPriceCents ?? totalPriceCents,
+        totalPriceCents,
+        taxable: true,
+        splittable: true,
+        confidence,
+        sourceText: line,
+      };
+      result.items.push(item);
+      pendingName = null;
+    }
+
+    if (result.totalCents === null) {
+      const itemSum = result.items.reduce((a, b) => a + b.totalPriceCents, 0);
+      result.totalCents = (result.subtotalCents ?? itemSum) - result.discountsCents + result.taxCents + result.tipCents;
+      result.lowConfidenceFields.push('totalCents');
+    }
+    if (result.subtotalCents === null) {
+      result.subtotalCents = result.items.reduce((a, b) => a + b.totalPriceCents, 0);
+      result.lowConfidenceFields.push('subtotalCents');
+    }
+
+    return result;
+  }
+
+  function estimateConfidence(line, name, price) {
+    let score = 0.9;
+    if (!price) score -= 0.5;
+    if (name.length < 2) score -= 0.3;
+    if (/\d{4,}/.test(name)) score -= 0.2;
+    if (/[^\x00-\x7F]/.test(line)) score -= 0.05;
+    return Math.max(0.05, Math.min(1, score));
+  }
+
+  return { parseReceiptText, parseMoneyToken, extractAllMoney };
+})();
+
+if (typeof module !== 'undefined') module.exports = ReceiptParser;

--- a/snapsplit/js/settings.js
+++ b/snapsplit/js/settings.js
@@ -1,0 +1,140 @@
+// SnapSplit — Settings: license, payment handles, cloud toggle, encrypted backup.
+'use strict';
+
+$('#btnSettings').addEventListener('click', () => openSettingsDialog());
+
+async function openSettingsDialog(focusSection) {
+  const wrap = el('div', { style: 'min-width:min(85vw,460px)' });
+  wrap.appendChild(el('h3', {}, '⚙️ Settings'));
+
+  const tabbar = el('div', { class: 'tabbar' });
+  const sections = { general: 'General', license: 'License', payment: 'Payment handles', backup: 'Backup' };
+  const body = el('div');
+  let active = focusSection && sections[focusSection] ? focusSection : 'general';
+
+  function draw() {
+    tabbar.innerHTML = '';
+    Object.entries(sections).forEach(([key, label]) => {
+      const b = el('button', { class: key === active ? 'active' : '' }, label);
+      b.addEventListener('click', () => { active = key; draw(); });
+      tabbar.appendChild(b);
+    });
+    body.innerHTML = '';
+    body.appendChild(
+      active === 'general' ? renderGeneralSection() :
+      active === 'license' ? renderLicenseSection() :
+      active === 'payment' ? renderPaymentSection() :
+      renderBackupSection()
+    );
+  }
+  draw();
+  wrap.append(tabbar, body);
+  wrap.appendChild(el('button', { class: 'btn ghost block', style: 'margin-top:14px', onclick: closeDialog }, 'Close'));
+  openDialog(wrap);
+}
+
+function renderGeneralSection() {
+  const box = el('div');
+  box.appendChild(el('p', { class: 'small muted' }, 'SnapSplit runs entirely in this browser. No account, no server, no tracking.'));
+  const themeRow = el('div', { class: 'row' });
+  ['light', 'dark', 'system'].forEach(mode => {
+    const btn = el('button', { class: 'btn sm' }, mode);
+    btn.addEventListener('click', () => {
+      if (mode === 'system') { document.documentElement.removeAttribute('data-theme'); localStorage.removeItem('snapsplit-theme'); }
+      else { document.documentElement.setAttribute('data-theme', mode); localStorage.setItem('snapsplit-theme', mode); }
+    });
+    themeRow.appendChild(btn);
+  });
+  box.appendChild(labeledField('Theme', themeRow));
+  return box;
+}
+
+function renderLicenseSection() {
+  const box = el('div');
+  box.appendChild(el('p', { class: 'small muted' }, 'Premium unlocks unlimited participants & saved splits, batch import, Trip Ledger, encrypted backup, CSV export, and branding removal.'));
+  const input = el('input', { type: 'text', placeholder: 'License key' });
+  box.appendChild(labeledField('License key', input));
+  const status = el('p', { class: 'small' });
+  box.appendChild(status);
+  const btn = el('button', {
+    class: 'btn primary', onclick: async () => {
+      status.textContent = 'Checking…';
+      const result = await Entitlements.validateLicense(input.value.trim());
+      await SnapDB.put('settings', { key: 'license', licenseKey: input.value.trim() });
+      status.textContent = result.valid ? `Licensed: ${result.plan}` : 'No active license — running in free mode. (Cloud license validation is not yet connected; see js/entitlements.js.)';
+    }
+  }, 'Validate');
+  box.appendChild(btn);
+  return box;
+}
+
+function renderPaymentSection() {
+  const box = el('div');
+  box.appendChild(el('p', { class: 'small muted' }, 'Stored only on this device. Used to build payment deep links on the Settle screen.'));
+  const venmo = el('input', { type: 'text', placeholder: '@your-venmo' });
+  const paypal = el('input', { type: 'text', placeholder: 'your-paypal-me' });
+  const cashapp = el('input', { type: 'text', placeholder: 'yourcashtag' });
+  SnapDB.get('settings', 'paymentHandles').then(saved => {
+    const v = (saved && saved.value) || {};
+    venmo.value = v.venmo || ''; paypal.value = v.paypal || ''; cashapp.value = v.cashapp || '';
+  });
+  box.appendChild(labeledField('Venmo', venmo));
+  box.appendChild(labeledField('PayPal.me', paypal));
+  box.appendChild(labeledField('Cash App', cashapp));
+  box.appendChild(el('button', {
+    class: 'btn primary', onclick: async () => {
+      await SnapDB.put('settings', { key: 'paymentHandles', value: { venmo: venmo.value.trim(), paypal: paypal.value.trim(), cashapp: cashapp.value.trim() } });
+      toast('Saved.', 'success');
+    }
+  }, 'Save handles'));
+  return box;
+}
+
+function renderBackupSection() {
+  const box = el('div');
+  box.appendChild(el('p', { class: 'small muted' }, 'Encrypted with AES-GCM using a passphrase only you know. Premium feature — export/import works here for evaluation even without a license so you can verify it end-to-end.'));
+  const pass = el('input', { type: 'password', placeholder: 'Backup passphrase' });
+  box.appendChild(labeledField('Passphrase', pass));
+
+  box.appendChild(el('button', {
+    class: 'btn primary block', onclick: async () => {
+      if (!pass.value) { toast('Enter a passphrase.', 'error'); return; }
+      const payload = {
+        splits: await SnapDB.getAll('splits'),
+        participants: await SnapDB.getAll('participants'),
+        trips: await SnapDB.getAll('trips'),
+        exportedAt: Date.now(),
+      };
+      const envelope = await CryptoBackup.encrypt(pass.value, payload);
+      downloadFile('snapsplit-backup.json', JSON.stringify(envelope), 'application/json');
+      toast('Encrypted backup downloaded.', 'success');
+    }
+  }, '⬇️ Export encrypted backup'));
+
+  const fileInput = el('input', { type: 'file', accept: 'application/json', class: 'visually-hidden' });
+  fileInput.addEventListener('change', async e => {
+    const f = e.target.files[0];
+    if (!f) return;
+    if (!pass.value) { toast('Enter the passphrase used to create this backup.', 'error'); return; }
+    try {
+      const envelope = JSON.parse(await f.text());
+      const data = await CryptoBackup.decrypt(pass.value, envelope);
+      for (const s of data.splits || []) await SnapDB.put('splits', s);
+      for (const p of data.participants || []) await SnapDB.put('participants', p);
+      for (const t of data.trips || []) await SnapDB.put('trips', t);
+      toast('Backup restored.', 'success');
+    } catch (err) {
+      toast('Could not decrypt — wrong passphrase or corrupted file.', 'error');
+    }
+  });
+  box.appendChild(el('button', { class: 'btn block', style: 'margin-top:8px', onclick: () => fileInput.click() }, '⬆️ Import encrypted backup'));
+  box.appendChild(fileInput);
+  return box;
+}
+
+function labeledField(label, inputEl) {
+  const f = el('div', { class: 'field' });
+  f.appendChild(el('label', {}, label));
+  f.appendChild(inputEl);
+  return f;
+}

--- a/snapsplit/js/step-assign.js
+++ b/snapsplit/js/step-assign.js
@@ -1,0 +1,198 @@
+// SnapSplit — Step 4: Assign items to people.
+'use strict';
+
+const SPLIT_MODES = [
+  { key: 'equal', label: 'Equal' },
+  { key: 'weighted', label: 'Weighted' },
+  { key: 'percentage', label: '%' },
+  { key: 'amount', label: '$' },
+  { key: 'quantity', label: 'Qty' },
+];
+
+function getOrCreateAssignment(itemId) {
+  if (!state.assignments[itemId]) state.assignments[itemId] = { mode: 'equal', shares: [] };
+  return state.assignments[itemId];
+}
+
+function renderAssignStep() {
+  const wrap = el('div');
+  const r = state.receipt;
+  const splittableItems = r.items.filter(i => i.splittable !== false);
+
+  const toolbar = el('div', { class: 'panel' });
+  const trow = el('div', { style: 'display:flex; justify-content:space-between; align-items:center; gap:10px; flex-wrap:wrap' });
+  trow.appendChild(el('h2', { style: 'margin:0' }, 'Assign items'));
+  const claimToggle = el('label', { style: 'display:flex; align-items:center; gap:6px; font-weight:600; font-size:13px' }, [
+    el('input', { type: 'checkbox', checked: state.claimMode }),
+    'Claim mode (pass the phone)',
+  ]);
+  claimToggle.querySelector('input').addEventListener('change', e => { state.claimMode = e.target.checked; renderStep(); });
+  trow.appendChild(claimToggle);
+  toolbar.appendChild(trow);
+
+  const unclaimed = splittableItems.filter(i => !hasAnyAssignment(i.id));
+  if (unclaimed.length) {
+    const bulk = el('div', { style: 'margin-top:10px' });
+    bulk.appendChild(el('p', { class: 'muted small' }, `${unclaimed.length} item(s) unclaimed.`));
+    const selectRow = el('div', { class: 'person-toggle-grid' });
+    const selectedIds = new Set();
+    state.participants.forEach(p => {
+      const t = el('button', { type: 'button', class: 'person-toggle' }, p.name);
+      t.addEventListener('click', () => {
+        t.classList.toggle('selected');
+        if (selectedIds.has(p.id)) selectedIds.delete(p.id); else selectedIds.add(p.id);
+      });
+      selectRow.appendChild(t);
+    });
+    bulk.appendChild(selectRow);
+    const assignAllBtn = el('button', {
+      class: 'btn sm primary', style: 'margin-top:8px', onclick: () => {
+        if (!selectedIds.size) { toast('Select at least one person first.', 'error'); return; }
+        unclaimed.forEach(item => {
+          state.assignments[item.id] = { mode: 'equal', shares: [...selectedIds].map(participantId => ({ participantId })) };
+        });
+        renderStep();
+      }
+    }, 'Assign all unclaimed to selected');
+    bulk.appendChild(assignAllBtn);
+    toolbar.appendChild(bulk);
+  }
+  wrap.appendChild(toolbar);
+
+  if (state.claimMode) {
+    wrap.appendChild(renderClaimModeView(splittableItems));
+  } else {
+    splittableItems.forEach(item => wrap.appendChild(renderAssignItemCard(item)));
+  }
+
+  return wrap;
+}
+
+function renderAssignItemCard(item) {
+  const assignment = getOrCreateAssignment(item.id);
+  const card = el('div', { class: 'assign-item-card' });
+  const head = el('div', { class: 'assign-item-head' });
+  head.appendChild(el('span', { class: 'name' }, `${item.name}${item.quantity > 1 ? ` ×${item.quantity}` : ''}`));
+  head.appendChild(el('span', { class: 'price' }, Money.format(item.totalPriceCents, state.receipt.currency)));
+  card.appendChild(head);
+
+  const tabs = el('div', { class: 'mode-tabs' });
+  SPLIT_MODES.forEach(m => {
+    const btn = el('button', { type: 'button', class: m.key === assignment.mode ? 'active' : '' }, m.label);
+    btn.addEventListener('click', () => { assignment.mode = m.key; normalizeShares(item, assignment); renderStep(); });
+    tabs.appendChild(btn);
+  });
+  card.appendChild(tabs);
+
+  const grid = el('div', { class: 'person-toggle-grid' });
+  state.participants.forEach(p => {
+    const share = assignment.shares.find(s => s.participantId === p.id);
+    const toggle = el('button', { type: 'button', class: 'person-toggle' + (share ? ' selected' : '') }, [
+      el('span', { class: 'avatar', style: `background:${colorForName(p.name)}; width:20px;height:20px;font-size:9px` }, initialsForName(p.name)),
+      ' ' + p.name,
+    ]);
+    toggle.addEventListener('click', () => {
+      if (share) assignment.shares = assignment.shares.filter(s => s.participantId !== p.id);
+      else assignment.shares.push({ participantId: p.id, value: defaultValueForMode(assignment.mode, p) });
+      normalizeShares(item, assignment);
+      renderStep();
+    });
+    grid.appendChild(toggle);
+  });
+  card.appendChild(grid);
+
+  if (['weighted', 'percentage', 'amount', 'quantity'].includes(assignment.mode) && assignment.shares.length) {
+    assignment.shares.forEach(s => {
+      const p = state.participants.find(x => x.id === s.participantId);
+      if (!p) return;
+      const row = el('div', { class: 'share-row' });
+      row.appendChild(el('span', {}, p.name));
+      const input = el('input', {
+        type: 'number', step: assignment.mode === 'amount' ? '0.01' : '0.1',
+        value: assignment.mode === 'amount' ? Money.fromCents(s.value || 0).toFixed(2) : (s.value ?? ''),
+      });
+      input.addEventListener('change', () => {
+        s.value = assignment.mode === 'amount' ? Money.toCents(input.value) : parseFloat(input.value) || 0;
+        renderStep();
+      });
+      row.appendChild(input);
+      row.appendChild(el('span', { class: 'muted small' }, assignment.mode === 'percentage' ? '%' : assignment.mode === 'quantity' ? `of ${item.quantity}` : ''));
+      card.appendChild(row);
+    });
+    card.appendChild(renderShareSummary(item, assignment));
+  }
+
+  return card;
+}
+
+function defaultValueForMode(mode, participant) {
+  if (mode === 'weighted') return participant.weight ?? 1;
+  if (mode === 'percentage') return 0;
+  if (mode === 'amount') return 0;
+  if (mode === 'quantity') return 1;
+  return undefined;
+}
+
+function normalizeShares(item, assignment) {
+  if (assignment.mode === 'equal') assignment.shares.forEach(s => delete s.value);
+}
+
+function renderShareSummary(item, assignment) {
+  const box = el('div', { class: 'small muted', style: 'margin-top:6px' });
+  if (assignment.mode === 'percentage') {
+    const total = assignment.shares.reduce((a, s) => a + (s.value || 0), 0);
+    box.textContent = `Total: ${total}% ${total !== 100 ? '(will be normalized to 100%)' : ''}`;
+  } else if (assignment.mode === 'amount') {
+    const total = assignment.shares.reduce((a, s) => a + (s.value || 0), 0);
+    box.textContent = `Total: ${Money.format(total, state.receipt.currency)} of ${Money.format(item.totalPriceCents, state.receipt.currency)} ${total !== item.totalPriceCents ? '(will be scaled to match item total)' : ''}`;
+  } else if (assignment.mode === 'quantity') {
+    const total = assignment.shares.reduce((a, s) => a + (s.value || 0), 0);
+    box.textContent = `Total: ${total} of ${item.quantity} units`;
+  }
+  return box;
+}
+
+/* ------------------------------ claim mode ------------------------------ */
+
+function renderClaimModeView(items) {
+  const box = el('div', { class: 'panel' });
+  let idx = items.findIndex(i => !hasAnyAssignment(i.id));
+  if (idx === -1) idx = 0;
+  if (!items.length) { box.appendChild(el('p', { class: 'muted' }, 'No items to claim.')); return box; }
+  const item = items[idx];
+  const assignment = getOrCreateAssignment(item.id);
+  assignment.mode = 'equal';
+
+  const card = el('div', { class: 'assign-item-card claim-mode' });
+  card.appendChild(el('div', { class: 'muted small' }, `Item ${idx + 1} of ${items.length}`));
+  card.appendChild(el('h2', { style: 'margin:6px 0' }, item.name));
+  card.appendChild(el('div', { class: 'price', style: 'font-size:22px; margin-bottom:14px' }, Money.format(item.totalPriceCents, state.receipt.currency)));
+
+  const grid = el('div', { class: 'person-toggle-grid', style: 'justify-content:center' });
+  state.participants.forEach(p => {
+    const selected = assignment.shares.some(s => s.participantId === p.id);
+    const btn = el('button', { type: 'button', class: 'person-toggle' + (selected ? ' selected' : ''), style: 'font-size:16px; padding:12px 18px' }, [
+      el('span', { class: 'avatar', style: `background:${colorForName(p.name)}` }, initialsForName(p.name)),
+      ' ' + p.name,
+    ]);
+    btn.addEventListener('click', () => {
+      if (selected) assignment.shares = assignment.shares.filter(s => s.participantId !== p.id);
+      else assignment.shares.push({ participantId: p.id });
+      renderStep();
+    });
+    grid.appendChild(btn);
+  });
+  card.appendChild(grid);
+
+  const nav = el('div', { class: 'row', style: 'margin-top:16px' });
+  nav.appendChild(el('button', { class: 'btn', disabled: idx === 0, onclick: () => { state._claimIdx = idx - 1; jumpClaim(items, idx - 1); } }, '← Previous'));
+  nav.appendChild(el('button', { class: 'btn primary', disabled: !assignment.shares.length, onclick: () => jumpClaim(items, idx + 1) }, idx === items.length - 1 ? 'Finish' : 'Next item →'));
+  card.appendChild(nav);
+  box.appendChild(card);
+  return box;
+}
+
+function jumpClaim(items, nextIdx) {
+  if (nextIdx >= items.length) { state.claimMode = false; toast('All items claimed.', 'success'); }
+  renderStep();
+}

--- a/snapsplit/js/step-people.js
+++ b/snapsplit/js/step-people.js
@@ -1,0 +1,107 @@
+// SnapSplit — Step 3: People.
+'use strict';
+
+function renderPeopleStep() {
+  const wrap = el('div');
+
+  const panel = el('div', { class: 'panel' });
+  panel.appendChild(el('h2', {}, 'Who’s splitting this?'));
+  panel.appendChild(el('p', { class: 'muted small' }, 'Add each person. Mark who paid, and adjust weight for kids or lighter appetites.'));
+
+  const list = el('div', { class: 'people-list' });
+  state.participants.forEach(p => list.appendChild(renderPersonChip(p)));
+  panel.appendChild(list);
+
+  const limits = Entitlements.limits();
+  const form = el('form', { class: 'row', style: 'margin-top:6px' });
+  const nameInput = el('input', { type: 'text', placeholder: 'Name', 'aria-label': 'Person name', autocomplete: 'off' });
+  const addBtn = el('button', { class: 'btn primary', type: 'submit' }, '+ Add');
+  form.append(nameInput, addBtn);
+  form.addEventListener('submit', async e => {
+    e.preventDefault();
+    const name = nameInput.value.trim();
+    if (!name) return;
+    if (state.participants.length >= limits.maxParticipants && !(await Entitlements.has('unlimitedParticipants'))) {
+      showUpsell(`Free plan is limited to ${limits.maxParticipants} participants.`, 'unlimitedParticipants');
+      return;
+    }
+    addParticipant(name);
+    nameInput.value = '';
+    renderStep();
+  });
+  panel.appendChild(form);
+  wrap.appendChild(panel);
+
+  wrap.appendChild(renderRecentParticipantsPanel());
+
+  return wrap;
+}
+
+function addParticipant(name, weight) {
+  state.participants.push({
+    id: uid('p'), name, weight: weight ?? 1, isPayer: state.participants.length === 0,
+  });
+}
+
+function renderPersonChip(p) {
+  const chip = el('div', { class: 'person-chip' });
+  chip.appendChild(el('div', { class: 'avatar', style: `background:${colorForName(p.name)}` }, initialsForName(p.name)));
+  const nameSpan = el('span', {}, p.name);
+  chip.appendChild(nameSpan);
+
+  const weightSel = el('select', { 'aria-label': `${p.name} weight`, style: 'min-height:30px; padding:2px 6px; font-size:12px' });
+  [[1, 'Full (1x)'], [0.5, 'Half (0.5x)'], [1.5, '1.5x']].forEach(([v, label]) => {
+    weightSel.appendChild(el('option', { value: v, selected: p.weight === v }, label));
+  });
+  weightSel.addEventListener('change', () => { p.weight = parseFloat(weightSel.value); });
+  chip.appendChild(weightSel);
+
+  if (p.isPayer) chip.appendChild(el('span', { class: 'payer-badge' }, 'Paid'));
+  else {
+    const payBtn = el('button', { class: 'btn sm ghost', style: 'padding:3px 8px; font-size:11px' }, 'Mark paid');
+    payBtn.addEventListener('click', () => { state.participants.forEach(x => x.isPayer = false); p.isPayer = true; renderStep(); });
+    chip.appendChild(payBtn);
+  }
+
+  const rm = el('button', { class: 'remove', 'aria-label': `Remove ${p.name}` }, '✕');
+  rm.addEventListener('click', () => {
+    state.participants = state.participants.filter(x => x.id !== p.id);
+    for (const a of Object.values(state.assignments)) {
+      if (a && a.shares) a.shares = a.shares.filter(s => s.participantId !== p.id);
+    }
+    renderStep();
+  });
+  chip.appendChild(rm);
+  return chip;
+}
+
+function renderRecentParticipantsPanel() {
+  const panel = el('div', { class: 'panel' });
+  panel.appendChild(el('h3', {}, 'Recent people'));
+  const box = el('div', { class: 'people-list' });
+  panel.appendChild(box);
+  SnapDB.getAll('participants').then(all => {
+    box.innerHTML = '';
+    const known = new Set(state.participants.map(p => p.name.toLowerCase()));
+    const recents = all.sort((a, b) => b.lastUsed - a.lastUsed).filter(p => !known.has(p.name.toLowerCase())).slice(0, 10);
+    if (!recents.length) { box.appendChild(el('p', { class: 'muted small' }, 'No recent participants yet.')); return; }
+    recents.forEach(p => {
+      const btn = el('button', { class: 'btn sm ghost' }, `+ ${p.name}`);
+      btn.addEventListener('click', () => { addParticipant(p.name, p.weight); renderStep(); });
+      box.appendChild(btn);
+    });
+  });
+  return panel;
+}
+
+function showUpsell(message, feature) {
+  const wrap = el('div');
+  wrap.appendChild(el('h3', {}, '✨ Premium'));
+  wrap.appendChild(el('p', { class: 'small' }, message));
+  wrap.appendChild(el('p', { class: 'small muted' }, `Feature key: ${feature}. Entitlements are centralized in js/entitlements.js — connect a real license provider there when ready.`));
+  const row = el('div', { class: 'row', style: 'margin-top:14px' });
+  row.appendChild(el('button', { class: 'btn ghost', onclick: closeDialog }, 'Close'));
+  row.appendChild(el('button', { class: 'btn primary', onclick: () => { closeDialog(); openSettingsDialog('license'); } }, 'Enter a license key'));
+  wrap.appendChild(row);
+  openDialog(wrap);
+}

--- a/snapsplit/js/step-review.js
+++ b/snapsplit/js/step-review.js
@@ -1,0 +1,205 @@
+// SnapSplit — Step 2: Review & correct extracted receipt data.
+'use strict';
+
+function renderReviewStep() {
+  const wrap = el('div');
+  const r = state.receipt;
+
+  const header = el('div', { class: 'panel' });
+  const hrow = el('div', { style: 'display:flex; justify-content:space-between; align-items:flex-start; gap:10px' });
+  const left = el('div', { style: 'flex:1' });
+  left.appendChild(labeledInput('Merchant', r.merchant, v => { pushHistory(); r.merchant = v; }));
+  left.appendChild(labeledInput('Date', r.date, v => { pushHistory(); r.date = v; }));
+  hrow.appendChild(left);
+  const right = el('div', { style: 'width:110px' });
+  right.appendChild(currencySelect(r));
+  hrow.appendChild(right);
+  header.appendChild(hrow);
+  const undoRow = el('div', { class: 'row', style: 'margin-top:10px' });
+  undoRow.appendChild(el('button', { class: 'btn sm', disabled: state.history.length === 0, onclick: undo }, '↶ Undo'));
+  undoRow.appendChild(el('button', { class: 'btn sm', disabled: state.future.length === 0, onclick: redo }, '↷ Redo'));
+  header.appendChild(undoRow);
+  wrap.appendChild(header);
+
+  const itemsPanel = el('div', { class: 'panel' });
+  itemsPanel.appendChild(el('h2', {}, 'Items'));
+  itemsPanel.appendChild(renderItemsTable(r));
+
+  const addRow = el('div', { class: 'row', style: 'margin-top:10px' });
+  addRow.appendChild(el('button', {
+    class: 'btn sm', onclick: () => {
+      pushHistory();
+      r.items.push({ id: uid('it'), name: 'New item', quantity: 1, unitPriceCents: 0, totalPriceCents: 0, taxable: true, splittable: true, confidence: 1, sourceText: '' });
+      renderStep();
+    }
+  }, '+ Add item'));
+  addRow.appendChild(el('button', { class: 'btn sm ghost', onclick: mergeDuplicateLines }, '⇄ Merge duplicates'));
+  itemsPanel.appendChild(addRow);
+  wrap.appendChild(itemsPanel);
+
+  const totalsPanel = el('div', { class: 'panel' });
+  totalsPanel.appendChild(el('h2', {}, 'Totals'));
+  totalsPanel.appendChild(renderTotalsFields(r));
+  totalsPanel.appendChild(renderTotalsGrid(r));
+  wrap.appendChild(totalsPanel);
+
+  return wrap;
+}
+
+function labeledInput(label, value, onChange, type) {
+  const f = el('div', { class: 'field' });
+  f.appendChild(el('label', {}, label));
+  const inp = el('input', { type: type || 'text', value: value || '' });
+  inp.addEventListener('change', () => onChange(inp.value));
+  f.appendChild(inp);
+  return f;
+}
+
+function currencySelect(r) {
+  const f = el('div', { class: 'field' });
+  f.appendChild(el('label', {}, 'Currency'));
+  const sel = el('select');
+  ['USD', 'EUR', 'GBP', 'CAD', 'AUD', 'JPY'].forEach(c => sel.appendChild(el('option', { value: c, selected: r.currency === c }, c)));
+  sel.addEventListener('change', () => { pushHistory(); r.currency = sel.value; renderStep(); });
+  f.appendChild(sel);
+  return f;
+}
+
+function renderItemsTable(r) {
+  const table = el('table', { class: 'items-table' });
+  const thead = el('thead', {}, el('tr', {}, [
+    el('th', {}, 'Item'), el('th', { style: 'width:52px' }, 'Qty'), el('th', { style: 'width:88px' }, 'Total'),
+    el('th', { style: 'width:120px' }, ''),
+  ]));
+  table.appendChild(thead);
+  const tbody = el('tbody');
+  r.items.forEach(item => tbody.appendChild(renderItemRow(item, r)));
+  table.appendChild(tbody);
+  return table;
+}
+
+function renderItemRow(item, r) {
+  const lowConf = (item.confidence ?? 1) < 0.6;
+  const tr = el('tr', { class: 'item-row' + (item.splittable === false ? ' non-splittable' : '') });
+
+  const nameTd = el('td');
+  const nameInput = el('input', { type: 'text', value: item.name, class: lowConf ? 'low-conf' : '' });
+  nameInput.addEventListener('change', () => { pushHistory(); item.name = nameInput.value; });
+  nameTd.appendChild(nameInput);
+  if (lowConf) nameTd.appendChild(el('div', { class: 'chip warn', style: 'margin-top:4px' }, 'low confidence'));
+  tr.appendChild(nameTd);
+
+  const qtyTd = el('td');
+  const qtyInput = el('input', { type: 'number', min: '0', step: '1', value: item.quantity, class: 'qty-input' });
+  qtyInput.addEventListener('change', () => {
+    pushHistory();
+    const q = Math.max(0, parseInt(qtyInput.value, 10) || 0);
+    item.quantity = q;
+  });
+  qtyTd.appendChild(qtyInput);
+  tr.appendChild(qtyTd);
+
+  const priceTd = el('td');
+  const priceInput = el('input', {
+    type: 'number', step: '0.01', value: Money.fromCents(item.totalPriceCents).toFixed(2), class: 'price-input',
+  });
+  priceInput.addEventListener('change', () => {
+    pushHistory();
+    item.totalPriceCents = Money.toCents(priceInput.value);
+    item.unitPriceCents = item.quantity ? Math.round(item.totalPriceCents / item.quantity) : item.totalPriceCents;
+  });
+  priceTd.appendChild(priceInput);
+  tr.appendChild(priceTd);
+
+  const actionsTd = el('td', { style: 'white-space:nowrap' });
+  const mkBtn = (label, title, fn) => el('button', { class: 'btn sm ghost', title, 'aria-label': title, style: 'padding:6px 8px' }, label);
+  const dupBtn = mkBtn('⧉', 'Duplicate', null);
+  dupBtn.addEventListener('click', () => { pushHistory(); r.items.push({ ...item, id: uid('it') }); renderStep(); });
+  const nonSplitBtn = mkBtn(item.splittable === false ? '☑' : '☐', 'Toggle non-splittable (e.g. subtotal line)', null);
+  nonSplitBtn.addEventListener('click', () => { pushHistory(); item.splittable = item.splittable === false ? true : false; renderStep(); });
+  const delBtn = mkBtn('✕', 'Delete', null);
+  delBtn.addEventListener('click', () => { pushHistory(); r.items = r.items.filter(i => i.id !== item.id); renderStep(); });
+  actionsTd.append(dupBtn, nonSplitBtn, delBtn);
+  tr.appendChild(actionsTd);
+
+  return tr;
+}
+
+function mergeDuplicateLines() {
+  const r = state.receipt;
+  pushHistory();
+  const byName = new Map();
+  const merged = [];
+  for (const item of r.items) {
+    const key = item.name.trim().toLowerCase();
+    if (byName.has(key)) {
+      const existing = byName.get(key);
+      existing.quantity += item.quantity;
+      existing.totalPriceCents += item.totalPriceCents;
+      existing.unitPriceCents = existing.quantity ? Math.round(existing.totalPriceCents / existing.quantity) : existing.totalPriceCents;
+    } else {
+      byName.set(key, item);
+      merged.push(item);
+    }
+  }
+  r.items = merged;
+  renderStep();
+  toast('Duplicate lines merged.', 'success');
+}
+
+function renderTotalsFields(r) {
+  const grid = el('div');
+  const row = el('div', { class: 'row' });
+  row.appendChild(moneyField('Subtotal (printed)', r.subtotalCents, v => { pushHistory(); r.subtotalCents = v; }));
+  row.appendChild(moneyField('Discounts', r.discountsCents, v => { pushHistory(); r.discountsCents = v; }));
+  grid.appendChild(row);
+  const row2 = el('div', { class: 'row' });
+  row2.appendChild(moneyField('Tax', r.taxCents, v => { pushHistory(); r.taxCents = v; }));
+  row2.appendChild(moneyField('Tip / gratuity', r.tipCents, v => { pushHistory(); r.tipCents = v; }));
+  grid.appendChild(row2);
+  grid.appendChild(moneyField('Total (printed)', r.totalCents, v => { pushHistory(); r.totalCents = v; }));
+  return grid;
+}
+
+function moneyField(label, cents, onChange) {
+  const f = el('div', { class: 'field' });
+  f.appendChild(el('label', {}, label));
+  const inp = el('input', { type: 'number', step: '0.01', value: Money.fromCents(cents || 0).toFixed(2) });
+  inp.addEventListener('change', () => { onChange(Money.toCents(inp.value)); renderStep(); });
+  f.appendChild(inp);
+  return f;
+}
+
+function renderTotalsGrid(r) {
+  const rec = CalcEngine.reconcileReceipt(r);
+  const box = el('div');
+  const grid = el('div', { class: 'totals-grid' });
+  const addRow = (label, cents) => {
+    grid.appendChild(el('div', { class: 'label' }, label));
+    grid.appendChild(el('div', { class: 'val' }, Money.format(cents, r.currency)));
+  };
+  addRow('Computed item subtotal', rec.itemSum);
+  addRow('Printed subtotal', rec.subtotalCents);
+  addRow('Item vs subtotal difference', rec.itemVsSubtotal);
+  addRow('Expected total (subtotal − discount + tax + tip)', rec.expectedTotal);
+  addRow('Printed total', r.totalCents);
+  addRow('Total discrepancy', rec.totalVsExpected);
+  box.appendChild(grid);
+
+  const banner = el('div', { class: 'discrepancy-banner ' + (rec.balanced ? 'good' : 'bad') });
+  if (rec.balanced) {
+    banner.appendChild(el('strong', {}, '✓ Receipt reconciles exactly.'));
+    state.discrepancyAcknowledged = true;
+  } else {
+    banner.appendChild(el('strong', {}, `⚠ This receipt does not reconcile (off by ${Money.format(Math.abs(rec.itemVsSubtotal) + Math.abs(rec.totalVsExpected), r.currency)}).`));
+    banner.appendChild(el('p', { class: 'small', style: 'margin:6px 0 0' }, 'Fix the item prices/totals above, or acknowledge and continue anyway — the split will still be computed exactly from whatever numbers you leave here.'));
+    const ackLabel = el('label', { style: 'display:flex; gap:8px; align-items:flex-start; margin-top:8px; font-weight:600' }, [
+      el('input', { type: 'checkbox', checked: state.discrepancyAcknowledged || false }),
+      'I understand this receipt has an unresolved discrepancy and want to continue anyway.',
+    ]);
+    ackLabel.querySelector('input').addEventListener('change', e => { state.discrepancyAcknowledged = e.target.checked; });
+    banner.appendChild(ackLabel);
+  }
+  box.appendChild(banner);
+  return box;
+}

--- a/snapsplit/js/step-scan.js
+++ b/snapsplit/js/step-scan.js
@@ -1,0 +1,225 @@
+// SnapSplit — Step 1: Scan. Capture, preprocess, OCR, parse.
+'use strict';
+
+function renderScanStep() {
+  const wrap = el('div');
+
+  wrap.appendChild(el('div', { class: 'privacy-note' }, [
+    el('span', {}, '🔒'),
+    el('span', {}, 'Receipt images stay on this device unless you explicitly enable cloud processing.'),
+  ]));
+
+  if (state.imagePreviewUrl && !state.receipt) {
+    wrap.appendChild(renderPreprocessPanel());
+    return wrap;
+  }
+
+  if (state.ocrBusy) {
+    wrap.appendChild(renderOcrProgressPanel());
+    return wrap;
+  }
+
+  const panel = el('div', { class: 'panel' });
+  panel.appendChild(el('h2', {}, 'Scan a receipt'));
+  panel.appendChild(el('p', { class: 'muted small' }, 'Photograph, upload, drag in, or paste a receipt image. OCR runs entirely in your browser.'));
+
+  const dz = el('div', { class: 'dropzone anim', tabindex: '0', role: 'button', 'aria-label': 'Upload or drop a receipt image' }, [
+    el('div', { class: 'big-emoji' }, '🧾'),
+    el('p', {}, el('strong', {}, 'Drop a receipt image here')),
+    el('p', { class: 'muted small' }, 'or use a button below'),
+  ]);
+  dz.addEventListener('click', () => $('#fileInputGeneric').click());
+  dz.addEventListener('dragover', e => { e.preventDefault(); dz.classList.add('drag'); });
+  dz.addEventListener('dragleave', () => dz.classList.remove('drag'));
+  dz.addEventListener('drop', e => {
+    e.preventDefault(); dz.classList.remove('drag');
+    const f = e.dataTransfer.files && e.dataTransfer.files[0];
+    if (f) handleFileSelected(f);
+  });
+  dz.addEventListener('keydown', e => { if (e.key === 'Enter' || e.key === ' ') $('#fileInputGeneric').click(); });
+  panel.appendChild(dz);
+
+  const grid = el('div', { class: 'capture-grid' });
+  const cameraInput = el('input', { type: 'file', accept: 'image/*', capture: 'environment', class: 'visually-hidden', id: 'fileInputCamera' });
+  const fileInput = el('input', { type: 'file', accept: 'image/*', class: 'visually-hidden', id: 'fileInputGeneric' });
+  [cameraInput, fileInput].forEach(inp => inp.addEventListener('change', e => {
+    const f = e.target.files && e.target.files[0];
+    if (f) handleFileSelected(f);
+    e.target.value = '';
+  }));
+  grid.appendChild(el('button', { class: 'btn primary', onclick: () => cameraInput.click() }, ['📷 ', 'Take photo']));
+  grid.appendChild(el('button', { class: 'btn', onclick: () => fileInput.click() }, ['🖼️ ', 'Choose file']));
+  panel.appendChild(grid);
+  panel.appendChild(cameraInput);
+  panel.appendChild(fileInput);
+
+  panel.appendChild(el('p', { class: 'muted small', style: 'margin-top:10px' },
+    'Tip: you can also press Ctrl/Cmd+V to paste a copied receipt image.'));
+
+  wrap.appendChild(panel);
+
+  const cloudPanel = el('div', { class: 'panel' });
+  cloudPanel.appendChild(el('h3', {}, 'Optional cloud OCR'));
+  cloudPanel.appendChild(el('p', { class: 'muted small' },
+    'Off by default. If enabled, you will be asked to confirm before any image ever leaves this device.'));
+  const cloudBtn = el('button', { class: 'btn sm ghost' }, 'Manage cloud processing…');
+  cloudBtn.addEventListener('click', openCloudSettingsDialog);
+  cloudPanel.appendChild(cloudBtn);
+  wrap.appendChild(cloudPanel);
+
+  setupPasteListener();
+  return wrap;
+}
+
+let pasteBound = false;
+function setupPasteListener() {
+  if (pasteBound) return;
+  pasteBound = true;
+  document.addEventListener('paste', e => {
+    if (state.step !== 'scan') return;
+    const items = e.clipboardData && e.clipboardData.items;
+    if (!items) return;
+    for (const it of items) {
+      if (it.type.startsWith('image/')) {
+        const f = it.getAsFile();
+        if (f) { handleFileSelected(f); break; }
+      }
+    }
+  });
+}
+
+async function handleFileSelected(file) {
+  try {
+    state.rawFile = file;
+    state.rotateDegrees = 0;
+    state.cropRect = null;
+    const canvas = await ImageProcessing.preprocess(file, { enhance: false });
+    state.previewCanvas = canvas;
+    const blob = await ImageProcessing.canvasToBlob(canvas, 'image/jpeg', 0.9);
+    state.imageBlob = blob;
+    state.imagePreviewUrl = URL.createObjectURL(blob);
+    state.imageHash = await SnapDB.hashImageBlob(blob).catch(() => null);
+    await checkDuplicate(state.imageHash);
+    renderStep();
+  } catch (err) {
+    toast('Could not read that image: ' + err.message, 'error');
+  }
+}
+
+async function checkDuplicate(hash) {
+  if (!hash) return;
+  const splits = await SnapDB.getAll('splits');
+  const dupe = splits.find(s => s.imageHash && SnapDB.hammingDistanceHex(s.imageHash, hash) <= 4);
+  if (dupe) {
+    toast(`Heads up: this looks like a receipt you already split (${dupe.merchant || 'unnamed'}).`, 'error');
+  }
+}
+
+function renderPreprocessPanel() {
+  const panel = el('div', { class: 'panel' });
+  panel.appendChild(el('h2', {}, 'Review the photo'));
+  panel.appendChild(el('p', { class: 'muted small' }, 'Rotate or crop for a cleaner scan, then run OCR.'));
+
+  const canvasWrap = el('div', { class: 'canvas-wrap' });
+  const img = el('img', { src: state.imagePreviewUrl, alt: 'Receipt preview' });
+  canvasWrap.appendChild(img);
+  panel.appendChild(canvasWrap);
+
+  const toolbar = el('div', { class: 'crop-toolbar' });
+  toolbar.appendChild(el('button', { class: 'btn sm', onclick: () => rotatePreview(-90) }, '⟲ Rotate left'));
+  toolbar.appendChild(el('button', { class: 'btn sm', onclick: () => rotatePreview(90) }, '⟳ Rotate right'));
+  toolbar.appendChild(el('button', {
+    class: 'btn sm ghost', onclick: () => {
+      state.imagePreviewUrl = null; state.imageBlob = null; state.rawFile = null; renderStep();
+    }
+  }, '✕ Discard'));
+  panel.appendChild(toolbar);
+
+  const grayLabel = el('label', { style: 'display:flex;align-items:center;gap:8px;margin-top:10px' }, [
+    el('input', { type: 'checkbox', id: 'chkEnhance', checked: true }),
+    'Enhance contrast & threshold for OCR (recommended)',
+  ]);
+  panel.appendChild(grayLabel);
+
+  panel.appendChild(el('button', {
+    class: 'btn primary block', style: 'margin-top:14px', onclick: () => runOcrFlow($('#chkEnhance').checked),
+  }, '✨ Extract items'));
+
+  return panel;
+}
+
+async function rotatePreview(delta) {
+  state.rotateDegrees = ((state.rotateDegrees || 0) + delta + 360) % 360;
+  const canvas = await ImageProcessing.preprocess(state.rawFile, { enhance: false, rotateDegrees: state.rotateDegrees });
+  const blob = await ImageProcessing.canvasToBlob(canvas, 'image/jpeg', 0.92);
+  URL.revokeObjectURL(state.imagePreviewUrl);
+  state.imageBlob = blob;
+  state.imagePreviewUrl = URL.createObjectURL(blob);
+  renderStep();
+}
+
+function renderOcrProgressPanel() {
+  const panel = el('div', { class: 'panel' });
+  panel.appendChild(el('h2', {}, 'Reading your receipt…'));
+  panel.appendChild(el('p', { class: 'muted small', id: 'ocrStatusText' }, 'Starting local OCR engine…'));
+  const bar = el('div', { class: 'progress-bar' }, el('div', { id: 'ocrProgressFill' }));
+  panel.appendChild(bar);
+  panel.appendChild(el('p', { class: 'muted small' }, 'The OCR model downloads once and is cached for offline reuse.'));
+  return panel;
+}
+
+async function runOcrFlow(enhance) {
+  state.ocrBusy = true;
+  renderStep();
+  try {
+    const canvas = await ImageProcessing.preprocess(state.rawFile, {
+      rotateDegrees: state.rotateDegrees, cropRect: state.cropRect, enhance,
+      contrast: 1.3, threshold: enhance ? 150 : null,
+    });
+    const blob = await ImageProcessing.canvasToBlob(canvas, 'image/png');
+    const text = await runTesseractOcr(blob, (status, progress) => {
+      const t = $('#ocrStatusText'); const f = $('#ocrProgressFill');
+      if (t) t.textContent = status;
+      if (f) f.style.width = Math.round(progress * 100) + '%';
+      announce(`${status} ${Math.round(progress * 100)}%`);
+    });
+    const parsed = ReceiptParser.parseReceiptText(text);
+    parsed.items.forEach(i => { i.splittable = true; });
+    state.receipt = parsed;
+    state.history = []; state.future = [];
+    state.discrepancyAcknowledged = false;
+    state.assignments = {};
+    state.ocrBusy = false;
+    toast('Extraction complete — please review.', 'success');
+    setStep('review');
+  } catch (err) {
+    state.ocrBusy = false;
+    toast('OCR failed: ' + err.message + '. You can still enter items manually.', 'error');
+    state.receipt = { merchant: '', date: '', currency: 'USD', items: [], subtotalCents: 0, discountsCents: 0, taxCents: 0, tipCents: 0, totalCents: 0, lowConfidenceFields: [] };
+    setStep('review');
+  }
+}
+
+/* ------------------------------ cloud opt-in dialog ------------------------------ */
+
+function openCloudSettingsDialog() {
+  const wrap = el('div');
+  wrap.appendChild(el('h3', {}, 'Cloud receipt processing'));
+  wrap.appendChild(el('p', { class: 'small' },
+    'Disabled by default. SnapSplit ships with no cloud OCR backend configured — enabling this only matters if you or your organization connect one.'));
+  wrap.appendChild(el('p', { class: 'small' }, 'If you enable it, before every use SnapSplit will: (1) tell you the receipt image is about to be uploaded, (2) name the destination, (3) require you to confirm, and (4) let you cancel.'));
+  const row = el('div', { class: 'row', style: 'margin-top:14px' });
+  row.appendChild(el('button', { class: 'btn ghost', onclick: closeDialog }, 'Close'));
+  row.appendChild(el('button', {
+    class: 'btn danger', onclick: async () => {
+      try {
+        await parseReceiptWithCloud(new Blob(), {});
+      } catch (err) {
+        toast(err.message, 'error');
+      }
+      closeDialog();
+    }
+  }, 'Try cloud parsing now'));
+  wrap.appendChild(row);
+  openDialog(wrap);
+}

--- a/snapsplit/js/step-settle.js
+++ b/snapsplit/js/step-settle.js
@@ -1,0 +1,270 @@
+// SnapSplit — Step 5: Settle. Compute, display, export, share.
+'use strict';
+
+function computeCurrentSplit() {
+  return CalcEngine.computeSplit(state.receipt, state.participants, state.assignments, {
+    taxMode: state.taxMode, tipMode: state.tipMode,
+  });
+}
+
+function renderSettleStep() {
+  const wrap = el('div');
+  const r = state.receipt;
+  const result = computeCurrentSplit();
+
+  const header = el('div', { class: 'panel' });
+  header.appendChild(el('h2', {}, r.merchant || 'Receipt split'));
+  header.appendChild(el('p', { class: 'muted small' }, [r.date, r.currency].filter(Boolean).join(' · ')));
+  const modeRow = el('div', { class: 'row' });
+  modeRow.appendChild(allocModeField('Tax allocation', state.taxMode, v => { state.taxMode = v; renderStep(); }));
+  modeRow.appendChild(allocModeField('Tip allocation', state.tipMode, v => { state.tipMode = v; renderStep(); }));
+  header.appendChild(modeRow);
+  if (!result.reconciles) {
+    header.appendChild(el('div', { class: 'discrepancy-banner bad', style: 'margin-top:10px' },
+      `⚠ Allocated total (${Money.format(result.grandTotal, r.currency)}) differs from receipt total (${Money.format(result.receiptTotalCents, r.currency)}) — this reflects the unresolved discrepancy acknowledged in Review.`));
+  }
+  if (result.unclaimedCents) {
+    header.appendChild(el('div', { class: 'discrepancy-banner bad', style: 'margin-top:10px' },
+      `${Money.format(result.unclaimedCents, r.currency)} in items are unclaimed and excluded from everyone's total.`));
+  }
+  wrap.appendChild(header);
+
+  const resultsPanel = el('div', { class: 'panel' });
+  resultsPanel.appendChild(el('h2', {}, 'Who owes what'));
+  state.participants.forEach(p => resultsPanel.appendChild(renderResultCard(p, result, r)));
+  wrap.appendChild(resultsPanel);
+
+  const settlePanel = el('div', { class: 'panel' });
+  settlePanel.appendChild(el('h2', {}, 'Settlement'));
+  settlePanel.appendChild(el('p', { class: 'small muted' }, 'Minimizing the number of payments is a greedy heuristic — not guaranteed mathematically optimal, but always exact in amount.'));
+  settlePanel.appendChild(renderSettlementInstructions(result, r, state.participants));
+  wrap.appendChild(settlePanel);
+
+  wrap.appendChild(renderAuditTrail(result, r));
+  wrap.appendChild(renderExportPanel(result, r));
+
+  return wrap;
+}
+
+function allocModeField(label, value, onChange) {
+  const f = el('div', { class: 'field' });
+  f.appendChild(el('label', {}, label));
+  const sel = el('select');
+  [['proportional', 'By item share'], ['equal', 'Equally']].forEach(([v, l]) => sel.appendChild(el('option', { value: v, selected: v === value }, l)));
+  sel.addEventListener('change', () => onChange(sel.value));
+  f.appendChild(sel);
+  return f;
+}
+
+function renderResultCard(p, result, r) {
+  const pr = result.perPerson[p.id];
+  const card = el('div', { class: 'result-card' });
+  const nameRow = el('div', { class: 'name-row' });
+  nameRow.appendChild(el('span', {}, [
+    el('span', { class: 'avatar', style: `background:${colorForName(p.name)}; margin-right:8px` }, initialsForName(p.name)),
+    p.name, p.isPayer ? ' (paid)' : '',
+  ]));
+  nameRow.appendChild(el('span', { class: 'owed' }, Money.format(pr.totalCents, r.currency)));
+  card.appendChild(nameRow);
+
+  const details = el('details');
+  details.appendChild(el('summary', {}, 'Breakdown'));
+  const table = el('table');
+  const addRow = (label, val) => table.appendChild(el('tr', {}, [el('td', {}, label), el('td', {}, Money.format(val, r.currency))]));
+  addRow('Items', pr.itemSubtotalCents);
+  addRow('Discount', -pr.discountShareCents);
+  addRow('Tax', pr.taxShareCents);
+  addRow('Tip', pr.tipShareCents);
+  details.appendChild(table);
+  card.appendChild(details);
+
+  const actions = el('div', { class: 'row', style: 'margin-top:8px' });
+  actions.appendChild(el('button', { class: 'btn sm ghost', onclick: () => copyText(individualSummaryText(p, pr, r), `Copied ${p.name}'s summary`) }, 'Copy'));
+  actions.appendChild(el('button', {
+    class: 'btn sm ghost', onclick: () => shareText(individualSummaryText(p, pr, r), `${p.name}'s share`),
+  }, 'Share'));
+  card.appendChild(actions);
+  return card;
+}
+
+function renderSettlementInstructions(result, r, participants) {
+  const box = el('div');
+  const totalPaidByPayers = {};
+  participants.forEach(p => { if (p.isPayer) totalPaidByPayers[p.id] = result.grandTotal; });
+  const numPayers = participants.filter(p => p.isPayer).length || 1;
+  const balances = participants.map(p => {
+    const pr = result.perPerson[p.id];
+    const paid = p.isPayer ? Math.round(result.grandTotal / numPayers) : 0;
+    return { id: p.id, name: p.name, net: paid - pr.totalCents };
+  });
+  const txns = CalcEngine.simplifyDebts(balances);
+  if (!txns.length) {
+    box.appendChild(el('p', { class: 'muted' }, 'Everyone is square — nothing to settle.'));
+    return box;
+  }
+  txns.forEach(t => {
+    box.appendChild(el('div', { class: 'result-card', style: 'display:flex; justify-content:space-between; align-items:center' }, [
+      el('span', {}, `${t.fromName} → ${t.toName}`),
+      el('strong', {}, Money.format(t.amountCents, r.currency)),
+    ]));
+  });
+  return box;
+}
+
+function renderAuditTrail(result, r) {
+  const panel = el('div', { class: 'panel' });
+  const details = el('details');
+  details.appendChild(el('summary', {}, el('h3', { style: 'display:inline' }, 'Calculation audit trail')));
+  const ul = el('ul', { class: 'small' });
+  result.audit.forEach(line => ul.appendChild(el('li', {}, line)));
+  details.appendChild(ul);
+  panel.appendChild(details);
+  return panel;
+}
+
+function summaryMarkdown(result, r, participants) {
+  let md = `# ${r.merchant || 'Receipt split'}\n\n`;
+  if (r.date) md += `Date: ${r.date}\n\n`;
+  md += `Total: ${Money.format(r.totalCents, r.currency)}\n\n`;
+  md += `| Person | Items | Tax | Tip | Discount | Total |\n|---|---|---|---|---|---|\n`;
+  participants.forEach(p => {
+    const pr = result.perPerson[p.id];
+    md += `| ${p.name} | ${Money.format(pr.itemSubtotalCents, r.currency)} | ${Money.format(pr.taxShareCents, r.currency)} | ${Money.format(pr.tipShareCents, r.currency)} | ${Money.format(-pr.discountShareCents, r.currency)} | **${Money.format(pr.totalCents, r.currency)}** |\n`;
+  });
+  md += `\n## Settlement\n`;
+  const box = document.createElement('div');
+  return md + settlementMarkdown(result, r, participants);
+}
+
+function settlementMarkdown(result, r, participants) {
+  const numPayers = participants.filter(p => p.isPayer).length || 1;
+  const balances = participants.map(p => {
+    const pr = result.perPerson[p.id];
+    const paid = p.isPayer ? Math.round(result.grandTotal / numPayers) : 0;
+    return { id: p.id, name: p.name, net: paid - pr.totalCents };
+  });
+  const txns = CalcEngine.simplifyDebts(balances);
+  if (!txns.length) return '\nEveryone is square.\n';
+  return txns.map(t => `- ${t.fromName} pays ${t.toName} ${Money.format(t.amountCents, r.currency)}`).join('\n') + '\n';
+}
+
+function individualSummaryText(p, pr, r) {
+  return `${p.name} owes ${Money.format(pr.totalCents, r.currency)} for ${r.merchant || 'the receipt'}` +
+    `\n(items ${Money.format(pr.itemSubtotalCents, r.currency)}, tax ${Money.format(pr.taxShareCents, r.currency)}, tip ${Money.format(pr.tipShareCents, r.currency)}, discount -${Money.format(pr.discountShareCents, r.currency)})`;
+}
+
+function copyText(text, msg) {
+  navigator.clipboard.writeText(text).then(() => toast(msg || 'Copied.', 'success')).catch(() => toast('Copy failed.', 'error'));
+}
+
+async function shareText(text, title) {
+  if (navigator.share) {
+    try { await navigator.share({ text, title }); } catch (e) { /* user cancelled */ }
+  } else {
+    copyText(text, 'Copied (share not supported on this browser).');
+  }
+}
+
+function downloadFile(filename, content, type) {
+  const blob = new Blob([content], { type });
+  const a = document.createElement('a');
+  a.href = URL.createObjectURL(blob);
+  a.download = filename;
+  a.click();
+  setTimeout(() => URL.revokeObjectURL(a.href), 4000);
+}
+
+function receiptToJson(result, r, participants) {
+  return JSON.stringify({
+    merchant: r.merchant, date: r.date, currency: r.currency,
+    totals: { subtotal: r.subtotalCents, discounts: r.discountsCents, tax: r.taxCents, tip: r.tipCents, total: r.totalCents },
+    participants: participants.map(p => ({ name: p.name, weight: p.weight, isPayer: !!p.isPayer, ...result.perPerson[p.id] })),
+    reconciles: result.reconciles,
+  }, null, 2);
+}
+
+function receiptToCsv(result, r, participants) {
+  const rows = [['Name', 'Items', 'Discount', 'Tax', 'Tip', 'Total']];
+  participants.forEach(p => {
+    const pr = result.perPerson[p.id];
+    rows.push([p.name, Money.fromCents(pr.itemSubtotalCents), Money.fromCents(-pr.discountShareCents), Money.fromCents(pr.taxShareCents), Money.fromCents(pr.tipShareCents), Money.fromCents(pr.totalCents)]);
+  });
+  return rows.map(r => r.map(c => `"${String(c).replace(/"/g, '""')}"`).join(',')).join('\n');
+}
+
+function renderExportPanel(result, r) {
+  const panel = el('div', { class: 'panel' });
+  panel.appendChild(el('h2', {}, 'Export & share'));
+  const grid = el('div', { class: 'capture-grid' });
+  grid.appendChild(el('button', { class: 'btn', onclick: () => copyText(summaryMarkdown(result, r, state.participants), 'Summary copied.') }, '📋 Copy summary'));
+  grid.appendChild(el('button', { class: 'btn', onclick: () => downloadFile(`${slug(r.merchant)}-split.md`, summaryMarkdown(result, r, state.participants), 'text/markdown') }, '⬇️ Download Markdown'));
+  grid.appendChild(el('button', { class: 'btn', onclick: () => downloadFile(`${slug(r.merchant)}-split.json`, receiptToJson(result, r, state.participants), 'application/json') }, '⬇️ Download JSON'));
+  grid.appendChild(el('button', { class: 'btn', onclick: () => window.print() }, '🖨️ Print view'));
+  grid.appendChild(el('button', { class: 'btn', onclick: () => shareText(summaryMarkdown(result, r, state.participants), 'SnapSplit result') }, '📤 Share'));
+  grid.appendChild(el('button', {
+    class: 'btn', onclick: async () => {
+      if (!(await Entitlements.has('csvExport'))) { showUpsell('CSV export is a premium feature.', 'csvExport'); return; }
+      downloadFile(`${slug(r.merchant)}-split.csv`, receiptToCsv(result, r, state.participants), 'text/csv');
+    }
+  }, '⬇️ CSV (premium)'));
+  panel.appendChild(grid);
+
+  const qrBtn = el('button', { class: 'btn block', style: 'margin-top:10px' }, '▦ Show QR code');
+  qrBtn.addEventListener('click', () => showQrDialog(result, r));
+  panel.appendChild(qrBtn);
+
+  panel.appendChild(renderPaymentLinksSection(result, r));
+
+  return panel;
+}
+
+function slug(s) { return (s || 'receipt').toLowerCase().replace(/[^a-z0-9]+/g, '-').slice(0, 40); }
+
+async function showQrDialog(result, r) {
+  const compact = {
+    m: r.merchant, t: Money.fromCents(r.totalCents),
+    p: state.participants.map(p => [p.name, Money.fromCents(result.perPerson[p.id].totalCents)]),
+  };
+  const payload = JSON.stringify(compact);
+  const wrap = el('div');
+  wrap.appendChild(el('h3', {}, 'Scan to share result'));
+  if (payload.length > 900) {
+    wrap.appendChild(el('p', { class: 'small' }, 'This split has too many participants/items to fit in a QR code — use Copy or Share instead.'));
+  } else {
+    const canvas = el('canvas');
+    wrap.appendChild(canvas);
+    try {
+      await QRCode.toCanvas(canvas, payload, { width: 260, margin: 1 });
+    } catch (e) {
+      wrap.appendChild(el('p', { class: 'small' }, 'Could not render QR code.'));
+    }
+    wrap.appendChild(el('p', { class: 'small muted' }, 'Contains only names & amounts — never the receipt image.'));
+  }
+  wrap.appendChild(el('button', { class: 'btn block', style: 'margin-top:10px', onclick: closeDialog }, 'Close'));
+  openDialog(wrap);
+}
+
+function renderPaymentLinksSection(result, r) {
+  const box = el('div', { style: 'margin-top:14px' });
+  box.appendChild(el('h3', {}, 'Payment links'));
+  box.appendChild(el('p', { class: 'small muted' }, 'Optional — enter your own handles in Settings. Nothing is hard-coded or shared.'));
+  SnapDB.get('settings', 'paymentHandles').then(saved => {
+    const handles = (saved && saved.value) || {};
+    const payer = state.participants.find(p => p.isPayer);
+    if (!payer) return;
+    const amountEach = state.participants.filter(p => !p.isPayer).map(p => result.perPerson[p.id].totalCents);
+    const links = el('div', { class: 'row' });
+    if (handles.venmo) links.appendChild(linkBtn('Venmo', `https://venmo.com/${encodeURIComponent(handles.venmo)}`));
+    if (handles.paypal) links.appendChild(linkBtn('PayPal.me', `https://paypal.me/${encodeURIComponent(handles.paypal)}`));
+    if (handles.cashapp) links.appendChild(linkBtn('Cash App', `https://cash.app/$${encodeURIComponent(handles.cashapp)}`));
+    if (!handles.venmo && !handles.paypal && !handles.cashapp) {
+      links.appendChild(el('button', { class: 'btn sm ghost', onclick: () => openSettingsDialog('payment') }, 'Add a payment handle'));
+    }
+    box.appendChild(links);
+  });
+  return box;
+}
+function linkBtn(label, href) {
+  const a = el('a', { href, target: '_blank', rel: 'noopener', class: 'btn sm' }, label);
+  return a;
+}

--- a/snapsplit/sw.js
+++ b/snapsplit/sw.js
@@ -1,0 +1,68 @@
+// SnapSplit service worker — caches the app shell for offline reuse.
+// Network-first for navigation, cache-first for static assets.
+'use strict';
+
+const CACHE_NAME = 'snapsplit-v1';
+const APP_SHELL = [
+  './',
+  './index.html',
+  './js/money.js',
+  './js/calc.js',
+  './js/parser.js',
+  './js/db.js',
+  './js/entitlements.js',
+  './js/cloud-adapter.js',
+  './js/crypto-backup.js',
+  './js/image-processing.js',
+  './js/ocr.js',
+  './js/app.js',
+  './js/step-scan.js',
+  './js/step-review.js',
+  './js/step-people.js',
+  './js/step-assign.js',
+  './js/step-settle.js',
+  './js/history.js',
+  './js/ledger.js',
+  './js/settings.js',
+  './js/debug.js',
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(APP_SHELL)).then(() => self.skipWaiting())
+  );
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys => Promise.all(keys.filter(k => k !== CACHE_NAME).map(k => caches.delete(k))))
+      .then(() => self.clients.claim())
+  );
+});
+
+self.addEventListener('fetch', event => {
+  const req = event.request;
+  if (req.method !== 'GET') return;
+
+  if (req.mode === 'navigate') {
+    event.respondWith(
+      fetch(req).then(res => {
+        caches.open(CACHE_NAME).then(cache => cache.put(req, res.clone()));
+        return res;
+      }).catch(() => caches.match(req).then(r => r || caches.match('./index.html')))
+    );
+    return;
+  }
+
+  event.respondWith(
+    caches.match(req).then(cached => {
+      if (cached) return cached;
+      return fetch(req).then(res => {
+        if (res.ok && req.url.startsWith(self.location.origin)) {
+          caches.open(CACHE_NAME).then(cache => cache.put(req, res.clone()));
+        }
+        return res;
+      }).catch(() => cached);
+    })
+  );
+});


### PR DESCRIPTION
Vanilla HTML/CSS/JS, no build step. Scan (camera/file/drop/paste) -> local
Tesseract.js OCR -> editable review with reconciliation -> people ->
per-item assignment (equal/weighted/%/amount/quantity) -> exact settlement.

Money math runs entirely in integer cents with largest-remainder rounding
(js/money.js, js/calc.js) so splits always sum exactly to the receipt
total. IndexedDB persistence, AES-GCM encrypted backup, centralized
entitlement gate for premium features (js/entitlements.js), isolated
disabled-by-default cloud OCR adapter, Trip Ledger with debt
simplification, and a ?debug=1 panel with pure-JS engine assertions.

Includes README, acceptance checklist, sample receipt fixtures, and a
link from the site landing page.